### PR TITLE
Update AI Studio document page toc.yml which has wrong hyperlink to ariticle

### DIFF
--- a/articles/ai-studio/toc.yml
+++ b/articles/ai-studio/toc.yml
@@ -65,7 +65,7 @@ items:
     - name: Create a project
       href: how-to/create-projects.md
     - name: Create and manage compute
-    href: how-to/create-manage-compute.md
+      href: how-to/create-manage-compute.md
   - name: Connect to services and resources
     items:
     - name: Connections overview


### PR DESCRIPTION
the wrong indentation  (missing two spaces) cause the toc hyperlink not pointing to the actual documentation.

https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/create-hub-project-sdk look at left toc, create-manage-compute link, it's pointing to the wrong url