### PR TITLE
Missing "then" clause in Azure Policy

### DIFF
--- a/articles/ai-services/openai/how-to/deployment-types.md
+++ b/articles/ai-services/openai/how-to/deployment-types.md
@@ -112,6 +112,9 @@ You can use the following policy to disable access to Azure OpenAI global standa
                     "equals": "GlobalStandard"
                 }
             ]
+        },
+        "then": {
+            "effect": "deny"
         }
     }
 }


### PR DESCRIPTION
Added missing "then" clause to complete Azure Policy. Otherwise, it may not disable the deployment type as intended.