### PR TITLE
Update how-to-access-data-interactive.md

### DIFF
--- a/articles/machine-learning/how-to-access-data-interactive.md
+++ b/articles/machine-learning/how-to-access-data-interactive.md
@@ -174,7 +174,7 @@ fs = AzureMachineLearningFileSystem(uri)
 
 # append csv files in folder to a list
 dflist = []
-for path in fs.glob('/<folder>/*.csv'):
+for path in fs.glob('<folder>/*.csv'):
     with fs.open(path) as f:
         dflist.append(pd.read_csv(f))
 
@@ -213,7 +213,7 @@ fs = AzureMachineLearningFileSystem(uri)
 
 # append parquet files in folder to a list
 dflist = []
-for path in fs.glob('/<folder>/*.parquet'):
+for path in fs.glob('<folder>/*.parquet'):
     with fs.open(path) as f:
         dflist.append(pd.read_parquet(f))
 


### PR DESCRIPTION
Removed extra slash in lines "for path in fs.glob('/>folder>/*.parquet'):" in sections: Read a folder of CSV files in to Pandas; Read a folder of parquet files into Pandas.