### PR TITLE
docs: Provide alternative login option to Azure CLI

### DIFF
--- a/articles/ai-studio/includes/install-cli.md
+++ b/articles/ai-studio/includes/install-cli.md
@@ -1,7 +1,7 @@
 ---
 title: include file
 description: include file
-author: sdgilley
+author: sdgilley, aliphys
 ms.reviewer: sgilley
 ms.author: sgilley
 ms.service: azure-ai-studio

--- a/articles/ai-studio/includes/install-cli.md
+++ b/articles/ai-studio/includes/install-cli.md
@@ -1,7 +1,7 @@
 ---
 title: include file
 description: include file
-author: sdgilley, aliphys
+author: sdgilley
 ms.reviewer: sgilley
 ms.author: sgilley
 ms.service: azure-ai-studio

--- a/articles/ai-studio/includes/install-cli.md
+++ b/articles/ai-studio/includes/install-cli.md
@@ -38,4 +38,9 @@ You can follow instructions [How to install the Azure CLI](/cli/azure/install-az
 After you install the Azure CLI, sign in using the ``az login`` command and sign-in using the browser:
 ```
 az login
+
+```
+Alternatively, you can log in manually via the browser with a device co
+```
+az login --use-device-code
 ```

--- a/articles/ai-studio/includes/install-cli.md
+++ b/articles/ai-studio/includes/install-cli.md
@@ -40,7 +40,7 @@ After you install the Azure CLI, sign in using the ``az login`` command and sign
 az login
 
 ```
-Alternatively, you can log in manually via the browser with a device co
+Alternatively, you can log in manually via the browser with a device code.
 ```
 az login --use-device-code
 ```


### PR DESCRIPTION
I have had difficulty logging into Azure via the `az login` PowerShell command. Using the option `--use-device-code` was smooth and easy.

Adding this to the CLI install section to share this knowledge with others (and my future self). 😁

This PR includes the commit only for this issue and replaces https://github.com/MicrosoftDocs/azure-ai-docs/pull/61
