### PR TITLE
Evaluate function `evaluator_config` reverses evaluator name and `column_mapping`

### DIFF
--- a/articles/ai-studio/how-to/develop/evaluate-sdk.md
+++ b/articles/ai-studio/how-to/develop/evaluate-sdk.md
@@ -432,8 +432,8 @@ result = evaluate(
     },
     # column mapping
     evaluator_config={
-        "column_mapping": {
-            "relevance": {
+        "relevance": {
+            "column_mapping": {
                 "query": "${data.queries}"
                 "ground_truth": "${data.ground_truth}"
                 "response": "${outputs.response}"
@@ -560,8 +560,8 @@ result = evaluate(
         "relevance": relevance_eval
     },
     evaluator_config={
-        "column_mapping": {
-            "default": {
+        "default": {
+            "column_mapping": {
                 "query": "${data.queries}"
                 "context": "${outputs.context}"
                 "response": "${outputs.response}"


### PR DESCRIPTION
[azure-ai-evaluation@1.0.0b5](https://pypi.org/project/azure-ai-evaluation/1.0.0b5/) expects:

```
    result = evaluate(
        data=dataset,
        evaluators=evaluators,
        # column mapping
        evaluator_config={
            "default": {
                "column_mapping": {
                    "query": "${data.question}",
                    "response": "${data.final_answer}",
                    "ground_truth": "${data.gold_final_answer}",
                    "context": "${data.context}",
                }
            }
        },
    )
```

The doc says:

```
from askwiki import askwiki

result = evaluate(
    data="data.jsonl",
    target=askwiki,
    evaluators={
        "relevance": relevance_eval
    },
    evaluator_config={
        "column_mapping": {
            "default": {
                "query": "${data.queries}"
                "context": "${outputs.context}"
                "response": "${outputs.response}"
            } 
        }
    }
)
```