### PR TITLE
Update concept-compute-target.md

### DIFF
--- a/articles/machine-learning/concept-compute-target.md
+++ b/articles/machine-learning/concept-compute-target.md
@@ -92,7 +92,7 @@ When created, these compute resources are automatically part of your workspace, 
 > [!NOTE]
 > To avoid charges when the compute is idle:
 > * For a compute *cluster*, make sure the minimum number of nodes is set to 0, or use [serverless compute](./how-to-use-serverless-compute.md).
-> * For a compute *instance*, [enable idle shutdown](how-to-create-compute-instance.md#configure-idle-shutdown).
+> * For a compute *instance*, [enable idle shutdown](how-to-create-compute-instance.md#configure-idle-shutdown). While stopping the compute instance stops the billing for compute hours, you'll still be billed for disk, public IP, and standard load balancer.
 
 ### Supported VM series and sizes
 


### PR DESCRIPTION
clarifying the note: for idleshutdown related to billing :  While stopping the compute instance stops the billing for compute hours, you'll still be billed for disk, public IP, and standard load balancer. https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-compute-instance?view=azureml-api-2&tabs=python#manage