### PR TITLE
Update `QAEvaluator` to indicate ground truth is required

### DIFF
--- a/articles/ai-studio/how-to/develop/evaluate-sdk.md
+++ b/articles/ai-studio/how-to/develop/evaluate-sdk.md
@@ -79,7 +79,7 @@ Built-in evaluators can accept *either* query and respons pairs or a list of con
 | `HateUnfairnessEvaluator`        | Required: String | Required: String | N/A           | N/A           |Supported |
 | `IndirectAttackEvaluator`      | Required: String | Required: String | Required: String | N/A           |Supported |
 | `ProtectedMaterialEvaluator`  | Required: String | Required: String | N/A           | N/A           |Supported |
-| `QAEvaluator`      | Required: String | Required: String | Required: String | N/A           | Not supported |
+| `QAEvaluator`      | Required: String | Required: String | Required: String | Required: String           | Not supported |
 | `ContentSafetyEvaluator`      | Required: String | Required: String |  N/A  | N/A           | Supported |
 
 - Query: the query sent in to the generative AI application


### PR DESCRIPTION
Since `QAEvaluator` is a composite that includes `SimilarityEvaluator` and `F1ScoreEvaluator`, both of which require `ground_truth` as an input, we should specify that `ground_truth` is required for the composite evaluator as well.