### PR TITLE
Update how-to-track-experiments-mlflow.md

### DIFF
--- a/articles/machine-learning/how-to-track-experiments-mlflow.md
+++ b/articles/machine-learning/how-to-track-experiments-mlflow.md
@@ -164,7 +164,7 @@ By default, experiments are in descending order by `start_time`, which is the ti
     ```
 
     > [!WARNING]
-    > Using `order_by` with expressions containing `metrics.*`, `params.*`, or `tags.*` in the parameter `order_by` isn't currently supported. Instead, use the `order_values` method from Pandas as shown in the example.
+    > Using `order_by` with expressions containing `metrics.*`, `params.*`, or `tags.*` in the parameter `order_by` isn't currently supported. Instead, use the `sort_values` method from Pandas as shown in the example.
 
 ### Filter runs
 


### PR DESCRIPTION
fix function name from "order_values" that does not exist in pandas to its correct name, "sort_values