### PR TITLE
Ensure Santali (Ol Chiki) Script Compliance with 'sat' Language Code

### DIFF
--- a/articles/ai-services/computer-vision/language-support.md
+++ b/articles/ai-services/computer-vision/language-support.md
@@ -89,7 +89,7 @@ The following table lists the OCR supported languages for print text by the most
 |French | `fr` |Sadri  (Devanagiri) | `sck` | 
 |Friulian  | `fur` | Samoan (Latin) | `sm`
 |Gagauz (Latin) | `gag`|Sanskrit (Devanagari) | `sa`|
-|Galician   | `gl` |Santali(Devanagiri) | `sat` | 
+|Galician   | `gl` |Santali(Ol Chiki) | `sat` | 
 |German | `de` | Scots  | `sco` | 
 |Gilbertese    | `gil` | Scottish Gaelic  | `gd` | 
 |Gondi (Devanagiri) | `gon`| Serbian (Latin) | `sr`, `sr-latn`|


### PR DESCRIPTION
The official script for the Santali language is the Ol Chiki script, and as such, we should use the standardized 'sat' language code that corresponds to this script. I am uncertain why the Devanagari script has been used for Santali in this instance. It is important to note that all government initiatives, both at the central and state levels in India, are published in the Ol Chiki script. Therefore, I strongly urge that no deviation from this standard occur. We have high expectations from multinational companies to ensure the adoption of the Santali language in its correct script, Ol Chiki, with the language code 'sat'.