### PR TITLE
Update copilot-sdk-evaluate.md

### DIFF
--- a/articles/ai-studio/tutorials/copilot-sdk-evaluate.md
+++ b/articles/ai-studio/tutorials/copilot-sdk-evaluate.md
@@ -98,7 +98,7 @@ In Part 1 of this tutorial series, you created an **.env** file that specifies t
 1. Install the required package:
 
     ```bash
-    pip install azure_ai-evaluation[prompts]
+    pip install azure-ai-evaluation[remote]
     ```
 
 1. Now run the evaluation script:


### PR DESCRIPTION
The module `azure_ai-evaluation[prompts]` does not exist, resulting in the following installation error: `WARNING: azure-ai-evaluation 1.0.1 does not provide the extra 'prompts'.`

According to the documentation, it should be: `pip install azure-ai-evaluation[remote]` in order to track results in AI Studio.