### PR TITLE
Add: japaneast for latest api version available list

### DIFF
--- a/articles/ai-services/document-intelligence/includes/preview-notice.md
+++ b/articles/ai-services/document-intelligence/includes/preview-notice.md
@@ -18,3 +18,4 @@ ms.date: 07/31/2024
 >   * **West US2**
 >   * **West Europe**
 >   * **North Central US**
+>   * **East Japan**


### PR DESCRIPTION
I have a Document Intelligence resource located in "japaneast". And now, I confirmed that I can use the latest API version (2024-07-31-preview) on my code (Python). I don't know whether other regions can use, but I confirmed that "japaneast" is supported now. So add "japaneast" to the list of regions that helps users to know where they can use the latest API version.

My environment:
- Document Intelligence
  - location: japaneast
  - plan: free
- Development environment
  - `azure-ai-documentintelligence==1.0.0b4`

My code
```Python
from azure.core.credentials import AzureKeyCredential
from azure.ai.documentintelligence import DocumentIntelligenceClient
from azure.ai.documentintelligence.models import AnalyzeResult
import os
from dotenv import load_dotenv
load_dotenv('.env')

endpoint = os.environ["FORM_RECOGNIZER_ENDPOINT"]
key = os.environ["FORM_RECOGNIZER_KEY"]
path_to_sample_documents ="sample-layout.xlsx"
# path_to_sample_documents = "sample-layout.docx"

document_analysis_client = DocumentIntelligenceClient(
    endpoint=endpoint, credential=AzureKeyCredential(key)
)

with open(path_to_sample_documents, "rb") as f:
    poller = document_analysis_client.begin_analyze_document(
        "prebuilt-layout", analyze_request=f, content_type="application/octet-stream"
    )

result: AnalyzeResult = poller.result()
print("modelId: {}".format(result.model_id))
print("apiVersion: {}".format(result.api_version))
print("content: {}".format(result.content))
```

The output is here:
```
$ uv run layout-test.py 
modelId: prebuilt-layout
apiVersion: 2024-07-31-preview ←-- HERE
content: Sheet1 
page1
Sheet2
page2
```