### PR TITLE
Remove unnecessary role assignment

### DIFF
--- a/articles/ai-services/openai/how-to/on-your-data-configuration.md
+++ b/articles/ai-services/openai/how-to/on-your-data-configuration.md
@@ -286,7 +286,6 @@ To enable the developers to use these resources to build applications, the admin
 |Role| Resource | Description |
 |--|--|--|
 | `Cognitive Services OpenAI Contributor` | Azure OpenAI | Call public ingestion API from Azure OpenAI Studio. The `Contributor` role is not enough, because if you only have `Contributor` role, you cannot call data plane API via Microsoft Entra ID authentication, and Microsoft Entra ID authentication is required in the secure setup described in this article. |
-| `Cognitive Services User` | Azure OpenAI | List API-Keys from Azure OpenAI Studio.|
 | `Contributor` | Azure AI Search | List API-Keys to list indexes from Azure OpenAI Studio.|
 | `Contributor` | Storage Account | List Account SAS to upload files from Azure OpenAI Studio.|
 | `Contributor` | The resource group or Azure subscription where the developer need to deploy the web app to | Deploy web app to the developer's Azure subscription.|


### PR DESCRIPTION
Remove "Cognitive Services User" because "Cognitive Services OpenAI Contributor" is enough for "Azure OpenAI" scope.