### PR TITLE
Fix synchronous translation code sample error.

### DIFF
--- a/articles/ai-services/translator/document-translation/quickstarts/includes/sdk/python.md
+++ b/articles/ai-services/translator/document-translation/quickstarts/includes/sdk/python.md
@@ -153,13 +153,13 @@ def sample_single_document_translation():
 
     # absolute path to your document
     file_path = "C:/{your-file-path}/document-translation-sample.docx"
-    file_name = os.path.path.basename(file_path)
+    file_name = os.path.basename(file_path)
     file_type = (
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     )
     print(f"File for translation: {file_name}")
 
-    with open(file_name, "r") as file:
+    with open(file_path, "rb") as file:
         file_contents = file.read()
 
     document_content = (file_name, file_contents, file_type)
@@ -168,8 +168,12 @@ def sample_single_document_translation():
     response_stream = client.document_translate(
         body=document_translate_content, target_language=target_language
     )
-    translated_response = response_stream.decode("utf-8-sig")  # type: ignore[attr-defined]
-    print(f"Translated response: {translated_response}")
+    # Save the response_stream to a file
+    output_file_path = "./translated-document.docx"
+    with open(output_file_path, "wb") as output_file:
+        output_file.write(response_stream)
+    
+    print(f"Translated document saved to: {output_file_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request includes changes to the `sample_single_document_translation` function in the `articles/ai-services/translator/document-translation/quickstarts/includes/sdk/python.md` file. The changes improve the handling of file paths and the saving of the translated document.

Improvements to file handling:

* Corrected the method used to obtain the file name from the file path by changing `os.path.path.basename` to `os.path.basename`.
* Changed the file opening mode from `"r"` (read) to `"rb"` (read binary) to correctly read the contents of the document.

Enhancements to translation response handling:

* Modified the code to save the translated document to a file instead of decoding and printing the response stream. This includes writing the response stream to a new file named `translated-document.docx`.Synchronous translation code sample for python is run in error. Propose to fix those errors.