### PR TITLE
Update fine-tuning.md - preview tag for Global Standard

### DIFF
--- a/articles/ai-services/openai/how-to/fine-tuning.md
+++ b/articles/ai-services/openai/how-to/fine-tuning.md
@@ -44,12 +44,12 @@ We use LoRA, or low rank approximation, to fine-tune models in a way that reduce
 
 ::: zone-end
 
-## Global Standard
+## Global Standard (preview)
 
-Azure OpenAI fine-tuning supports [global standard deployments](./deployment-types.md#global-standard) in East US2, North Central US, and Sweden Central for:
+Azure OpenAI fine-tuning supports, [global standard deployments](./deployment-types.md#global-standard) in East US2, North Central US, and Sweden Central for:
 
-- `gpt-4o-2024-08-06`
 - `gpt-4o-mini-2024-07-18`
+- `gpt-4o-2024-08-06` (currently unavailable for new deployments, until January 2025)
 
 Global standard fine-tuned deployments offer [cost savings](https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/), but custom model weights may temporarily be stored outside the geography of your Azure OpenAI resource.
 


### PR DESCRIPTION
Update FT documentation to include the preview tag for the Global Standard and update status of 4o deployments

We need this change in response to IcM https://portal.microsofticm.com/imp/v5/incidents/details/579797846/activity/notifications where 4o deployments are no longer available for Global Standard SKU.

Also, this feature's doc was missing a preview note, so I've added that.