### PR TITLE
update an old API version for 2024 to the latest one

### DIFF
--- a/articles/ai-services/document-intelligence/concept/add-on-capabilities.md
+++ b/articles/ai-services/document-intelligence/concept/add-on-capabilities.md
@@ -93,7 +93,7 @@ The task of recognizing small text from large-size documents, like engineering d
 ### [REST API](#tab/rest-api)
 
 ```bash
-{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-02-29-preview&features=ocrHighResolution
+{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&features=ocrHighResolution
 ```
 
 ### [Sample code](#tab/sample-code)
@@ -362,7 +362,7 @@ The `ocr.formula` capability extracts all identified formulas, such as mathemati
 ### [REST API](#tab/rest-api)
 
 ```bash
-{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-02-29-preview&features=formulas
+{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&features=formulas
 ```
 
 ### [Sample code](#tab/sample-code)
@@ -509,7 +509,7 @@ The `ocr.font` capability extracts all font properties of text extracted in the 
 ### [REST API](#tab/rest-api)
 
 ```bash
-  {your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-02-29-preview&features=styleFont
+  {your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&features=styleFont
 ```
 
 ### [Sample code](#tab/sample-code)
@@ -766,7 +766,7 @@ The `ocr.barcode` capability extracts all identified barcodes in the `barcodes` 
 ### [REST API](#tab/rest-api)
 
 ```bash
-{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-02-29-preview&features=barcodes
+{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&features=barcodes
 ```
 
 ### [Sample code](#tab/sample-code)
@@ -875,7 +875,7 @@ Adding the `languages` feature to the `analyzeResult` request predicts the detec
 ### [REST API](#tab/rest-api)
 
 ```bash
-{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-02-29-preview&features=languages
+{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&features=languages
 ```
 
 ### [Sample code](#tab/sample-code)
@@ -1025,7 +1025,7 @@ Keys can also exist in isolation when the model detects that a key exists, with 
 ### REST API
 
 ```bash
-{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-02-29-preview&features=keyValuePairs
+{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&features=keyValuePairs
 ```
 
 ## Query Fields
@@ -1065,7 +1065,7 @@ For query field extraction, specify the fields you want to extract and Document 
 ### [REST API](#tab/rest-api)
 
 ```bash
-{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-02-29-preview&features=queryFields&queryFields=TERMS
+{your-resource-endpoint}.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&features=queryFields&queryFields=TERMS
 ```
 
 ### [Sample code](#tab/sample-code)

--- a/articles/ai-services/document-intelligence/concept/incremental-classifier.md
+++ b/articles/ai-services/document-intelligence/concept/incremental-classifier.md
@@ -56,7 +56,7 @@ The incremental classifier build request is similar to the [`classify document` 
 
 ***Sample `POST` request to build an incremental document classifier***
 
-**`POST` {your-endpoint}/documentintelligence/documentClassifiers:build?api-version=2024-02-29-preview**
+**`POST` {your-endpoint}/documentintelligence/documentClassifiers:build?api-version=2024-11-30**
 
 ```json
 {
@@ -94,7 +94,7 @@ Upon successful completion:
 
 ***Sample `GET` request to retrieve the result of an incremental document classifier***
 
-**`GET` {your-endpoint}/documentintelligence/documentClassifiers/{classifierId}/analyzeResults/{resultId}?api-version=2024-02-29-preview**
+**`GET` {your-endpoint}/documentintelligence/documentClassifiers/{classifierId}/analyzeResults/{resultId}?api-version=2024-11-30**
 
 ```json
 

--- a/articles/ai-services/document-intelligence/concept/query-fields.md
+++ b/articles/ai-services/document-intelligence/concept/query-fields.md
@@ -50,7 +50,7 @@ For query field extraction, specify the fields you want to extract and Document 
 Use the query fields feature with the [general document model](../prebuilt/general-document.md), and add fields to the extraction process without having to train a custom model:
 
 ```http
-POST https://{endpoint}/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-02-29-preview&features=queryFields&queryFields=Terms,PaymentDate HTTP/1.1
+POST https://{endpoint}/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&features=queryFields&queryFields=Terms,PaymentDate HTTP/1.1
 Host: *.cognitiveservices.azure.com
 Content-Type: application/json
 Ocp-Apim-Subscription-Key:

--- a/articles/ai-services/document-intelligence/how-to-guides/disaster-recovery.md
+++ b/articles/ai-services/document-intelligence/how-to-guides/disaster-recovery.md
@@ -66,7 +66,7 @@ The process for copying a custom model consists of the following steps:
 The following HTTP request gets copy authorization from your target resource. You need to enter the endpoint and key of your target resource as headers.
 
 ```http
-POST https://<your-resource-endpoint>/documentintelligence/documentModels:authorizeCopy?api-version=2024-02-29-preview
+POST https://<your-resource-endpoint>/documentintelligence/documentModels:authorizeCopy?api-version=2024-11-30
 Ocp-Apim-Subscription-Key: {<your-key>}
 ```
 
@@ -97,7 +97,7 @@ You receive a `200` response code with response body that contains the JSON payl
 The following HTTP request starts the copy operation on the source resource. You need to enter the endpoint and key of your source resource as the url and header. Notice that the request URL contains the model ID of the source model you want to copy.
 
 ```http
-POST https://<your-resource-endpoint>/documentintelligence/documentModels/{modelId}:copyTo?api-version=2024-02-29-preview
+POST https://<your-resource-endpoint>/documentintelligence/documentModels/{modelId}:copyTo?api-version=2024-11-30
 Ocp-Apim-Subscription-Key: {<your-key>}
 ```
 
@@ -118,7 +118,7 @@ You receive a `202\Accepted` response with an Operation-Location header. This va
 
 ```http
 HTTP/1.1 202 Accepted
-Operation-Location: https://<your-resource-endpoint>.cognitiveservices.azure.com/documentintelligence/operations/{operation-id}?api-version=2024-02-29-preview
+Operation-Location: https://<your-resource-endpoint>.cognitiveservices.azure.com/documentintelligence/operations/{operation-id}?api-version=2024-11-30
 ```
 
 > [!NOTE]
@@ -127,7 +127,7 @@ Operation-Location: https://<your-resource-endpoint>.cognitiveservices.azure.com
 ## Track Copy progress
 
 ```console
-GET https://<your-resource-endpoint>.cognitiveservices.azure.com/documentintelligence/operations/{<operation-id>}?api-version=2024-02-29-preview
+GET https://<your-resource-endpoint>.cognitiveservices.azure.com/documentintelligence/operations/{<operation-id>}?api-version=2024-11-30
 Ocp-Apim-Subscription-Key: {<your-key>}
 ```
 
@@ -136,7 +136,7 @@ Ocp-Apim-Subscription-Key: {<your-key>}
 You can also use the **[`Get model`](/rest/api/aiservices/document-models/get-model?view=rest-aiservices-2023-07-31&preserve-view=true&tabs=HTTP)** API to track the status of the operation by querying the target model. Call the API using the target model ID that you copied down from the [`Generate copy authorization` request](#generate-copy-authorization-request) response.
 
 ```http
-GET https://<your-resource-endpoint>/documentintelligence/documentModels/{modelId}?api-version=2024-02-29-preview" -H "Ocp-Apim-Subscription-Key: <your-key>
+GET https://<your-resource-endpoint>/documentintelligence/documentModels/{modelId}?api-version=2024-11-30" -H "Ocp-Apim-Subscription-Key: <your-key>
 ```
 
 In the response body, you see information about the model. Check the `"status"` field for the status of the model.
@@ -156,7 +156,7 @@ The following code snippets use cURL to make API calls. You also need to fill in
 **Request**
 
 ```bash
-curl -i -X POST "<your-resource-endpoint>/documentintelligence/documentModels:authorizeCopy?api-version=2024-02-29-preview"
+curl -i -X POST "<your-resource-endpoint>/documentintelligence/documentModels:authorizeCopy?api-version=2024-11-30"
 -H "Content-Type: application/json"
 -H "Ocp-Apim-Subscription-Key: <YOUR-KEY>"
 --data-ascii "{
@@ -183,7 +183,7 @@ curl -i -X POST "<your-resource-endpoint>/documentintelligence/documentModels:au
 **Request**
 
 ```bash
-curl -i -X POST "<your-resource-endpoint>/documentintelligence/documentModels/{modelId}:copyTo?api-version=2024-02-29-preview"
+curl -i -X POST "<your-resource-endpoint>/documentintelligence/documentModels/{modelId}:copyTo?api-version=2024-11-30"
 -H "Content-Type: application/json"
 -H "Ocp-Apim-Subscription-Key: <YOUR-KEY>"
 --data-ascii "{
@@ -201,7 +201,7 @@ curl -i -X POST "<your-resource-endpoint>/documentintelligence/documentModels/{m
 
 ```http
 HTTP/1.1 202 Accepted
-Operation-Location: https://<your-resource-endpoint>.cognitiveservices.azure.com/documentintelligence/operations/{operation-id}?api-version=2024-02-29-preview
+Operation-Location: https://<your-resource-endpoint>.cognitiveservices.azure.com/documentintelligence/operations/{operation-id}?api-version=2024-11-30
 ```
 
 ### Track copy operation progress
@@ -233,7 +233,7 @@ The process for copying a custom model consists of the following steps:
 The following HTTP request gets copy authorization from your target resource. You need to enter the endpoint and key of your target resource as headers.
 
 ```http
-POST https://{TARGET_FORM_RECOGNIZER_RESOURCE_ENDPOINT}/formrecognizer/documentModels:authorizeCopy?api-version=2024-02-29-preview
+POST https://{TARGET_FORM_RECOGNIZER_RESOURCE_ENDPOINT}/formrecognizer/documentModels:authorizeCopy?api-version=2024-11-30
 Ocp-Apim-Subscription-Key: {TARGET_FORM_RECOGNIZER_RESOURCE_KEY}
 ```
 

--- a/articles/ai-services/document-intelligence/how-to-guides/includes/v4-0/rest-api.md
+++ b/articles/ai-services/document-intelligence/how-to-guides/includes/v4-0/rest-api.md
@@ -63,7 +63,7 @@ Use the following table as a reference. Replace *\<modelId>* and *\<document-url
 Open a console window and run the following cURL command. The commands include the endpoint and key environment variables previously created in the set environment variables section. Replace those variables if your variable names differ. Remember to replace the *\<modelId>* and *\<document-url>* parameters.
 
 ```console
-curl -i -X POST "%DI_ENDPOINT%/documentintelligence/documentModels/{modelId}:analyze?api-version=2024-02-29-preview" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: %DI_KEY%" --data-ascii "{'urlSource': '<document-url>'}"
+curl -i -X POST "%DI_ENDPOINT%/documentintelligence/documentModels/{modelId}:analyze?api-version=2024-11-30" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: %DI_KEY%" --data-ascii "{'urlSource': '<document-url>'}"
 ```
 
 To enable add-on capabilities, use the `features` query parameter in the POST request. There are four add-on capabilities available with the `2023-07-31` (GA) and later releases: *ocr.highResolution*, *ocr.formula*, *ocr.font*, and *queryFields.premium*. To learn more about each of the capabilities, see [Custom models](../../../concept/accuracy-confidence.md).
@@ -71,7 +71,7 @@ To enable add-on capabilities, use the `features` query parameter in the POST re
 You can only call the *highResolution*, *formula*, and *font* capabilities for the Read and Layout model, and the *queryFields* capability for the General Documents model. The following example shows how to call the *highResolution*, *formula*, and *font* capabilities for the Layout model.
 
 ```bash
-curl -i -X POST "%DI_ENDPOINT%documentintelligence/documentModels/prebuilt-layout:analyze?features=ocr.highResolution,ocr.formula,ocr.font?api-version=2024-02-29-preview" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: %DI_KEY%" --data-ascii "{'urlSource': '<document-url>'}"
+curl -i -X POST "%DI_ENDPOINT%documentintelligence/documentModels/prebuilt-layout:analyze?features=ocr.highResolution,ocr.formula,ocr.font?api-version=2024-11-30" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: %DI_KEY%" --data-ascii "{'urlSource': '<document-url>'}"
 ```
 
 ### POST response
@@ -101,7 +101,7 @@ Use the NodeJS *json tool* as a JSON formatter for cURL. If you don't have [Node
 1. Pretty print the JSON output by including the pipe character `| json` with your GET requests.
 
    ```console
-   curl -i -X GET "<endpoint>documentintelligence/documentModels/prebuilt-read/analyzeResults/0e49604a-2d8e-4b15-b6b8-bb456e5d3e0a?api-version=2024-02-29-preview"-H "Ocp-Apim-Subscription-Key: <subscription key>" | json
+   curl -i -X GET "<endpoint>documentintelligence/documentModels/prebuilt-read/analyzeResults/0e49604a-2d8e-4b15-b6b8-bb456e5d3e0a?api-version=2024-11-30"-H "Ocp-Apim-Subscription-Key: <subscription key>" | json
    ```
 
 #### [macOS](#tab/macOS)
@@ -111,7 +111,7 @@ The *json_pp* command tool ships with macOS and can be used as a JSON formatter 
 - Pretty print the JSON output by including `| json_pp` with your GET requests.
 
   ```console
-  curl -i -X GET "{endpoint}documentintelligence/documentModels/prebuilt-read/analyzeResults/0e49604a-2d8e-4b15-b6b8-bb456e5d3e0a?api-version=2024-02-29-preview"-H "Ocp-Apim-Subscription-Key: <subscription key>" | json_pp
+  curl -i -X GET "{endpoint}documentintelligence/documentModels/prebuilt-read/analyzeResults/0e49604a-2d8e-4b15-b6b8-bb456e5d3e0a?api-version=2024-11-30"-H "Ocp-Apim-Subscription-Key: <subscription key>" | json_pp
   ```
 
 #### [Linux](#tab/linux)
@@ -121,7 +121,7 @@ The *json_pp* command line tool is preinstalled in most Linux distributions. If 
 - Pretty print the JSON output by including `| json_pp` with your `GET` requests.
 
   ```console
-  curl -i -X GET "<endpoint>documentintelligence/documentModels/prebuilt-read/analyzeResults/0e49604a-2d8e-4b15-b6b8-bb456e5d3e0a?api-version=2024-02-29-preview"-H "Ocp-Apim-Subscription-Key: <subscription key>" | json_pp
+  curl -i -X GET "<endpoint>documentintelligence/documentModels/prebuilt-read/analyzeResults/0e49604a-2d8e-4b15-b6b8-bb456e5d3e0a?api-version=2024-11-30"-H "Ocp-Apim-Subscription-Key: <subscription key>" | json_pp
   ```
 
 ---

--- a/articles/ai-services/document-intelligence/train/custom-classifier.md
+++ b/articles/ai-services/document-intelligence/train/custom-classifier.md
@@ -153,7 +153,7 @@ When using the REST API, if you organize your documents by folders, you can use 
 
 ```json
 
-https://{endpoint}/documentintelligence/documentClassifiers:build?api-version=2024-02-29-preview
+https://{endpoint}/documentintelligence/documentClassifiers:build?api-version=2024-11-30
 
 {
   "classifierId": "demo2.1",
@@ -350,7 +350,7 @@ Analyze an input file with the document classification model.
 :::moniker range="doc-intel-4.0.0"
 
 ```json
-https://{endpoint}/documentintelligence/documentClassifiers/{classifier}:analyze?api-version=2024-02-29-preview
+https://{endpoint}/documentintelligence/documentClassifiers/{classifier}:analyze?api-version=2024-11-30
 ```
 
 The `v4.0 2024-11-30 (GA)` API enables you to specify pages to analyze from the input document using the `pages` query parameter in the request.


### PR DESCRIPTION
I have updated an old API version for 2024 to the latest one. The old API version was deprecated, so if you use the old API version, you will get an error response from it. 

Actually, when I read one of the documents I changed, I tried executing the following command, which is written in the document, but I got an error response(I'm not sure but the status code was 404 probably).
`curl -i -X POST "%DI_ENDPOINT%documentintelligence/documentModels/prebuilt-layout:analyze?features=ocr.highResolution,ocr.formula,ocr.font?api-version=2024-02-29-preview" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: %DI_KEY%" --data-ascii "{'urlSource': '<document-url>'}"`