### PR TITLE
Update tutorial-rag-build-solution-pipeline.md

### DIFF
--- a/articles/search/tutorial-rag-build-solution-pipeline.md
+++ b/articles/search/tutorial-rag-build-solution-pipeline.md
@@ -196,7 +196,7 @@ embedding_skill = AzureOpenAIEmbeddingSkill(
     resource_url=AZURE_OPENAI_ACCOUNT,  
     deployment_name="text-embedding-3-large",  
     model_name="text-embedding-3-large",
-    dimensions=1536,
+    dimensions=1024,
     inputs=[  
         InputFieldMappingEntry(name="text", source="/document/pages/*"),  
     ],  


### PR DESCRIPTION
Section: Create a skillset
Site: https://learn.microsoft.com/en-us/azure/search/tutorial-rag-build-solution-pipeline?source=docs#create-a-skillset Proposed change:
* Edit the AzureOpenAIEmbeddingSkill dimension to 1024. Reason: 
* The SearchField (text_vector) and the AzureOpenAIEmbeddingSkill dimension must match, else, an error will be raised, Error:
here's a mismatch in vector dimensions. The vector field 'text_vector'_ with dimension of '1024'	 expects a length of '1024'. However	 the provided vector has a length of '1536'. Please ensure that the vector length matches the expected length of the vector field. Read the following documentation for more details: https://learn.microsoft.com/en-us/azure/search/vector-search-how-to-configure-compression-storage.'	'https://go.microsoft.com/fwlink/?linkid=2113719'