### PR TITLE
Remove unrequired code

### DIFF
--- a/articles/search/includes/quickstarts/python-semantic.md
+++ b/articles/search/includes/quickstarts/python-semantic.md
@@ -106,7 +106,6 @@ semantic_config = SemanticConfiguration(
 # Create the semantic settings with the configuration
 semantic_search = SemanticSearch(configurations=[semantic_config])
 
-semantic_settings = SemanticSearch(configurations=[semantic_config])
 scoring_profiles = []
 suggester = [{'name': 'sg', 'source_fields': ['Tags', 'Address/City', 'Address/Country']}]
 


### PR DESCRIPTION
Below code is defined, but never used.

```Python
semantic_settings = SemanticSearch(configurations=[semantic_config])
```