### PR TITLE
Update reference-migrate-sdk-v1-mlflow-tracking.md

### DIFF
--- a/articles/machine-learning/reference-migrate-sdk-v1-mlflow-tracking.md
+++ b/articles/machine-learning/reference-migrate-sdk-v1-mlflow-tracking.md
@@ -388,13 +388,13 @@ run_id = finished_mlflow_run.info.run_id
 
 ## View run artifacts
 
-To view the artifacts of a run, use [MlFlowClient.list_artifacts](https://mlflow.org/docs/latest/python_api/mlflow.tracking.html#mlflow.tracking.MlflowClient.list_artifacts):
+To view the artifacts of a run, use [MlFlowClient.list_artifacts](https://mlflow.org/docs/latest/python_api/mlflow.artifacts.html#mlflow.artifacts.list_artifacts):
 
 ```python
 client.list_artifacts(finished_mlflow_run.info.run_id)
 ```
 
-To download an artifact, use [mlflow.artifacts.download_artifacts](https://www.mlflow.org/docs/latest/python_api/mlflow.tracking.html#mlflow.tracking.MlflowClient.download_artifacts):
+To download an artifact, use [mlflow.artifacts.download_artifacts](https://mlflow.org/docs/latest/python_api/mlflow.artifacts.html#mlflow.artifacts.download_artifacts):
 
 ```python
 mlflow.artifacts.download_artifacts(run_id=finished_mlflow_run.info.run_id, artifact_path="Azure.png")


### PR DESCRIPTION
Two URLs were broken because of this change: https://github.com/mlflow/mlflow/issues/7620
I changed the URLs to redirect to the appropriate official MLFlow documentation. 