### PR TITLE
Update reference-migrate-sdk-v1-mlflow-tracking.md

### DIFF
--- a/articles/machine-learning/reference-migrate-sdk-v1-mlflow-tracking.md
+++ b/articles/machine-learning/reference-migrate-sdk-v1-mlflow-tracking.md
@@ -363,7 +363,7 @@ params = finished_mlflow_run.data.params
 ```
 
 > [!NOTE]
-> The `metrics` will only have the most recently logged value for a given metric. For example, if you log in order a value of `1`, then `2`, `3`, and finally `4` to a metric named `sample_metric`, only `4` will be present in the `metrics` dictionary. To get all metrics logged for a specific named metric, use [MlFlowClient.get_metric_history](https://mlflow.org/docs/latest/python_api/mlflow.tracking.html#mlflow.tracking.MlflowClient.get_metric_history):
+> The `metrics` will only have the most recently logged value for a given metric. For example, if you log in order a value of `1`, then `2`, `3`, and finally `4` to a metric named `sample_metric`, only `4` will be present in the `metrics` dictionary. To get all metrics logged for a specific named metric, use [MlFlowClient.get_metric_history](https://mlflow.org/docs/latest/python_api/mlflow.client.html?highlight=get_metric_history#mlflow.client.MlflowClient.get_metric_history):
 >
 > ```python
 > with mlflow.start_run() as multiple_metrics_run:
@@ -376,7 +376,7 @@ params = finished_mlflow_run.data.params
 > print(client.get_metric_history(multiple_metrics_run.info.run_id, "sample_metric"))
 > ```
 > 
-> For more information, see the [MlFlowClient](https://mlflow.org/docs/latest/python_api/mlflow.tracking.html#mlflow.tracking.MlflowClient) reference.
+> For more information, see the [MlFlowClient](https://mlflow.org/docs/latest/python_api/mlflow.client.html?highlight=get_metric_history#module-mlflow.client) reference.
 
 The `info` field provides general information about the run, such as start time, run ID, experiment ID, etc.:
 


### PR DESCRIPTION
When clicking on the link MlFlowClient.get_metric_history it links to a non-existent page.
Same thing happens with MlFlowClient reference.

Fixed both and changed the URLs to the appropriate ones.