### PR TITLE
Update how-to-manage-compute-instance.md

### DIFF
--- a/articles/machine-learning/how-to-manage-compute-instance.md
+++ b/articles/machine-learning/how-to-manage-compute-instance.md
@@ -55,6 +55,9 @@ Start at [Azure Machine Learning studio](https://ml.azure.com).
 
 ---
 
+> [!NOTE]
+> When configuring a Virtual Network (VNet) located in a different resource group from your Azure Machine Learning workspace, be aware that resources such as Network Security Groups (NSGs), Public IPs, and Load Balancers will be created in the same resource group as the VNet. This behavior ensures proper network management and isolation.
+
 ## Manage
 
 Start, stop, restart, and delete a compute instance. A compute instance doesn't always automatically scale down, so make sure to stop the resource to prevent ongoing charges. Stopping a compute instance deallocates it. Then start it again when you need it. While stopping the compute instance stops the billing for compute hours, you'll still be billed for disk, public IP, and standard load balancer. 
@@ -154,6 +157,9 @@ For each compute instance in a workspace that you created (or that was created f
     * Create or modify the schedule for starting and stopping the compute instance. Scroll down to the bottom of the page to edit the schedule.
 
 ---
+
+> [!Caution]
+> Applying resource locks, such as "Delete" or "Read-only", to the resource group containing your compute instances can prevent operations like creation, resizing, or deletion of these instances. Ensure that resource locks are configured appropriately to avoid unintended disruptions. 
 
 [Azure RBAC](/azure/role-based-access-control/overview) allows you to control which users in the workspace can create, delete, start, stop, restart a compute instance. All users in the workspace contributor and owner role can create, delete, start, stop, and restart compute instances across the workspace. However, only the creator of a specific compute instance, or the user assigned if it was created on their behalf, is allowed to access Jupyter, JupyterLab, and RStudio on that compute instance. A compute instance is dedicated to a single user who has root access. That user has access to Jupyter/JupyterLab/RStudio running on the instance. Compute instance has single-user sign-in and all actions use that user's identity for Azure RBAC and attribution of experiment jobs. SSH access is controlled through public/private key mechanism.
 


### PR DESCRIPTION
Updated document with below proposed changes:

Clarification about resource locations in the context of a workspace's resource group:
When resources such as Network Security Groups (NSGs), Public IPs, and Load Balancers are not in the same resource group as the Azure Machine Learning workspace, it's important to specify this in the documentation.
For example, if the VNET (Virtual Network) is located in a separate resource group for management purposes, customers should understand that these resources will be created in the same resource group as the VNET, not necessarily the workspace's resource group.

The documentation should explicitly note this distinction to avoid customers assuming that all resources are created in the workspace's resource group.
Expand resource lock behavior documentation for Compute Instances:
Resource locks can affect creation of a Compute Instance, not just resizing.
The documentation should include this information and explicitly state that locks can prevent both the creation and resizing of Compute Instances.
This clarification will help ensure customers are aware of potential issues caused by resource locks during either operation.