### PR TITLE
Update how-to-create-attach-compute-cluster.md

### DIFF
--- a/articles/machine-learning/how-to-create-attach-compute-cluster.md
+++ b/articles/machine-learning/how-to-create-attach-compute-cluster.md
@@ -57,6 +57,9 @@ Start at [Azure Machine Learning studio](https://ml.azure.com).
 
 ---
 
+> [!NOTE]
+> When configuring a Virtual Network (VNet) located in a different resource group from your Azure Machine Learning workspace, be aware that resources such as Network Security Groups (NSGs), Public IPs, and Load Balancers will be created in the same resource group as the VNet. This behavior ensures proper network management and isolation.
+
 ## What is a compute cluster?
 
 Azure Machine Learning compute cluster is a managed-compute infrastructure that allows you to easily create a single or multi-node compute. The compute cluster is a resource that can be shared with other users in your workspace. The compute scales up automatically when a job is submitted, and can be put in an Azure Virtual Network. Compute cluster supports **no public IP** deployment as well in virtual network. The compute executes in a containerized environment and packages your model dependencies in a [Docker container](https://www.docker.com/why-docker).
@@ -73,6 +76,9 @@ Compute clusters can run jobs securely in either a [managed virtual network](how
 * Azure Machine Learning Compute has default limits, such as the number of cores that can be allocated. For more information, see [Manage and request quotas for Azure resources](how-to-manage-quotas.md).
 
 * Azure allows you to place *locks* on resources, so that they can't be deleted or are read only. **Do not apply resource locks to the resource group that contains your workspace**. Applying a lock to the resource group that contains your workspace prevents scaling operations for Azure Machine Learning compute clusters. For more information on locking resources, see [Lock resources to prevent unexpected changes](/azure/azure-resource-manager/management/lock-resources).
+
+> [!Caution]
+> Applying resource locks, such as "Delete" or "Read-only", to the resource group containing your compute clusters can prevent operations like creation, scaling, or deletion of these clusters. Ensure that resource locks are configured appropriately to avoid unintended disruptions. 
 
 ## Create
 


### PR DESCRIPTION
Updated doc based on the below suggestions:

Clarification about resource locations in the context of a workspace's resource group:
When resources such as Network Security Groups (NSGs), Public IPs, and Load Balancers are not in the same resource group as the Azure Machine Learning workspace, it's important to specify this in the documentation.
For example, if the VNET (Virtual Network) is located in a separate resource group for management purposes, customers should understand that these resources will be created in the same resource group as the VNET, not necessarily the workspace's resource group.

The documentation should explicitly note this distinction to avoid customers assuming that all resources are created in the workspace's resource group.
Expand resource lock behavior documentation for Compute Instances:
Resource locks can affect creation of a Compute Instance, not just resizing.
The documentation should include this information and explicitly state that locks can prevent both the creation and resizing of Compute Instances.
This clarification will help ensure customers are aware of potential issues caused by resource locks during either operation.