### PR TITLE
fix the message to be for Azure Machine Learning workspace resource i…

### DIFF
--- a/articles/machine-learning/how-to-create-compute-instance.md
+++ b/articles/machine-learning/how-to-create-compute-instance.md
@@ -154,7 +154,7 @@ A compute instance won't be considered idle if any custom application is running
 Also, if a compute instance has already been idle for a certain amount of time, if idle shutdown settings are updated to  an amount of time shorter than the current idle duration, the idle time clock is reset to 0. For example, if the compute instance has already been idle for 20 minutes, and the shutdown settings are updated to 15 minutes, the idle time clock is reset to 0.
 
 > [!IMPORTANT]
-> If the compute instance is also configured with a [managed identity](#assign-managed-identity), the compute instance won't shut down due to inactivity unless the managed identity has *contributor* access to the Azure Machine Learning workspace. For more information on assigning permissions, see [Manage access to Azure Machine Learning workspaces](how-to-assign-roles.md).
+> If the Azure Machine Learning workspace resource is also configured with a [managed identity](#assign-managed-identity), the compute instance won't shut down due to inactivity unless the managed identity has *contributor* access to the Azure Machine Learning workspace. For more information on assigning permissions, see [Manage access to Azure Machine Learning workspaces](how-to-assign-roles.md).
 
 The setting can be configured during compute instance creation or for existing compute instances via the following interfaces:
 


### PR DESCRIPTION
…nstead of compute instance resource

it seems mistakenly mentioned that the targeted identity is the compute instance one, however, it should be the identity of the workspace itself.