### PR TITLE
Correct reference to LlamaIndex in LangChain article

### DIFF
--- a/articles/ai-studio/how-to/develop/langchain.md
+++ b/articles/ai-studio/how-to/develop/langchain.md
@@ -21,7 +21,7 @@ Models deployed to Azure AI Foundry can be used with LangChain in two ways:
 
 - **Using the Azure AI model inference API:** All models deployed to Azure AI Foundry support the [Azure AI model inference API](../../../ai-foundry/model-inference/reference/reference-model-inference-api.md), which offers a common set of functionalities that can be used for most of the models in the catalog. The benefit of this API is that, since it's the same for all the models, changing from one to another is as simple as changing the model deployment being use. No further changes are required in the code. When working with LangChain, install the extensions `langchain-azure-ai`.
 
-- **Using the model's provider specific API:** Some models, like OpenAI, Cohere, or Mistral, offer their own set of APIs and extensions for LlamaIndex. Those extensions may include specific functionalities that the model support and hence are suitable if you want to exploit them. When working with LangChain, install the extension specific for the model you want to use, like `langchain-openai` or `langchain-cohere`.
+- **Using the model's provider specific API:** Some models, like OpenAI, Cohere, or Mistral, offer their own set of APIs and extensions for LangChain. Those extensions may include specific functionalities that the model support and hence are suitable if you want to exploit them. When working with LangChain, install the extension specific for the model you want to use, like `langchain-openai` or `langchain-cohere`.
 
 In this tutorial, you learn how to use the packages `langchain-azure-ai` to build applications with LangChain.
 


### PR DESCRIPTION
A statement in the Develop apps with LangChain article cites LlamaIndex. I changed this to LangChain.