### PR TITLE
PE as a pre-requisite for disabling Public IP

### DIFF
--- a/articles/ai-studio/how-to/configure-managed-network.md
+++ b/articles/ai-studio/how-to/configure-managed-network.md
@@ -142,6 +142,7 @@ Before following the steps in this article, make sure you have the following pre
 * Data exfiltration protection is automatically enabled for the only approved outbound mode. If you add other outbound rules, such as to FQDNs, Microsoft can't guarantee that you're protected from data exfiltration to those outbound destinations.
 * Using FQDN outbound rules increases the cost of the managed virtual network because FQDN rules use Azure Firewall. For more information, see [Pricing](#pricing).
 * FQDN outbound rules only support ports 80 and 443.
+* If you want to disable compute instance's Public IP, you must add a private endpoint to a hub.
 * When using a compute instance with a managed network, use the `az ml compute connect-ssh` command to connect to the compute using SSH.
 * If your managed network is configured to __allow only approved outbound__, you can't use an FQDN rule to access Azure Storage Accounts. You must use a private endpoint instead.
 


### PR DESCRIPTION
Compute Instance in Azure AI Foundry can have its Public IP disabled only if AI Hub has a private endpoint configured.