### PR TITLE
Update docs: trace-local-sdk.md

### DIFF
--- a/articles/ai-studio/how-to/develop/trace-local-sdk.md
+++ b/articles/ai-studio/how-to/develop/trace-local-sdk.md
@@ -43,7 +43,8 @@ Install the package `azure-ai-inference` using your package manager, like pip:
 Install the Azure Core OpenTelemetry Tracing plugin, OpenTelemetry, and the OTLP exporter for sending telemetry to your observability backend. To install the necessary packages for Python, use the following pip commands:
 
 ```bash
-pip install opentelemetry 
+pip install opentelemetry-api
+pip install opentelemetry-sdk
 
 pip install opentelemetry-exporter-otlp 
 ```


### PR DESCRIPTION
The opentelemetry package is no longer available on PyPI. 
This PR updates the dependencies to use the correct packages:

- Added: opentelemetry-api and opentelemetry-sdk
- Removed: opentelemetry (no longer available)

Let me know if further adjustments are needed! 