### PR TITLE
Add specification of same subnet requirement for AML Registry

### DIFF
--- a/articles/machine-learning/how-to-registry-network-isolation.md
+++ b/articles/machine-learning/how-to-registry-network-isolation.md
@@ -140,7 +140,7 @@ Example operations:
 * Use a component from registry in a pipeline.
 * Use an environment from registry in a component.
 
-Create a private endpoint to the registry, storage and ACR from the VNet of the workspace. If you're trying to connect to multiple registries, create private endpoint for each registry and associated storage and ACRs. For more information, see the [How to create a private endpoint](#how-to-create-a-private-endpoint) section.
+Create a private endpoint to the registry, storage and ACR in the **same subnet** as the private endpoint of the AML workspace. If you're trying to connect to multiple registries, create private endpoint for each registry and associated storage and ACRs. For more information, see the [How to create a private endpoint](#how-to-create-a-private-endpoint) section.
 
 ### Deploy a model from registry to workspace 
 


### PR DESCRIPTION
## Context

If machine Learning Registry private endpoint was deployed in a different subnet within the same virtual network, we were not able to use components registered in the registry. Deploying all the private endpoints in the same subnet has been indicated as the solution by some people and it works. I propose this change to make the documentation explicit
