### PR TITLE
Update keyless-connections.md SearchClient arg

### DIFF
--- a/articles/search/keyless-connections.md
+++ b/articles/search/keyless-connections.md
@@ -196,7 +196,7 @@ credential = DefaultAzureCredential(authority=authority)
 
 search_client = SearchClient(
     endpoint=service_endpoint, 
-    index=index_name, 
+    index_name=index_name, 
     credential=credential, 
     audience=audience)
 


### PR DESCRIPTION
The SearchClient takes in `index_name`, not `index`. 

Below is the constructor:
```
SearchClient(endpoint: str, index_name: str, credential: AzureKeyCredential | TokenCredential, **kwargs: Any)
```

https://learn.microsoft.com/en-us/python/api/azure-search-documents/azure.search.documents.searchclient?view=azure-python