### PR TITLE
Fix typo

### DIFF
--- a/articles/machine-learning/v1/how-to-consume-web-service.md
+++ b/articles/machine-learning/v1/how-to-consume-web-service.md
@@ -150,7 +150,7 @@ print(primary)
 
 #### Authentication with tokens
 
-When you enable token authentication for a web service, a user must provide an Azure Machine Learning JWT token to the web service to access it. 
+When you enable token authentication for a web service, a user must provide an Azure Machine Learning JWT to the web service to access it. 
 
 * Token authentication is disabled by default when you're deploying to Azure Kubernetes Service.
 * Token authentication isn't supported when you're deploying to Azure Container Instances.

--- a/articles/machine-learning/v1/how-to-deploy-azure-kubernetes-service.md
+++ b/articles/machine-learning/v1/how-to-deploy-azure-kubernetes-service.md
@@ -354,7 +354,7 @@ To enable token authentication, set the `token_auth_enabled=True` parameter when
 deployment_config = AksWebservice.deploy_configuration(cpu_cores=1, memory_gb=1, token_auth_enabled=True)
 ```
 
-If token authentication is enabled, you can use the `get_token` method to retrieve a JWT token and that token's expiration time:
+If token authentication is enabled, you can use the `get_token` method to retrieve a JWT and that token's expiration time:
 
 ```python
 token, refresh_by = service.get_token()


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.