### PR TITLE
[Typo] Change parameter used for abstractive summarisation payload

### DIFF
--- a/articles/ai-services/language-service/summarization/how-to/text-summarization.md
+++ b/articles/ai-services/language-service/summarization/how-to/text-summarization.md
@@ -296,7 +296,7 @@ curl -i -X POST https://<your-language-resource-endpoint>/language/analyze-text/
       "kind": "AbstractiveSummarization",
       "taskName": "Length controlled Abstractive Summarization",
           "parameters": {
-          "sentenceLength": "short"
+          "summaryLength": "short"
       }
     }
   ]


### PR DESCRIPTION
## Fix Typo

`sentenceLength` is not supported by Abstractive Summarisation `summaryLength` should be used instead. This looks to be a typo as it is used only for Extractive Summarisation. 