### PR TITLE
Update release notes for cli-v2

### DIFF
--- a/articles/machine-learning/azure-machine-learning-release-notes-cli-v2.md
+++ b/articles/machine-learning/azure-machine-learning-release-notes-cli-v2.md
@@ -24,16 +24,27 @@ In this article, learn about Azure Machine Learning CLI (v2) releases.
 __RSS feed__: Get notified when this page is updated by copying and pasting the following URL into your feed reader:
 `https://learn.microsoft.com/api/search/rss?search=%22Azure+machine+learning+release+notes-v2%22&locale=en-us`
 
+## 2025-03-12
+
+## Azure Machine Learning CLI (v2) v 2.36.0
+- `az ml compute update`
+  - Fix updating compute when ssh is enabled.
+ 
+## 2025-01-08
+
+## Azure Machine Learning CLI (v2) v 2.34.0
+- `az ml workspace update --network-acls`
+  - Added `--network-acls` property to allow user to specify IPs or IP ranges in CIDR notation for workspace access.
+- `az ml capability-host`
+  - Added create operation
+  - Added get operation
+  - Added delete operation
+
 ## 2024-12-17
 
-### Azure Machine Learning CLI (v2) v2.33.0
-
+## Azure Machine Learning CLI (v2) v 2.33.0
 - `az ml workspace create --provision-network-now`
-  - Added `--provision-network-now` property to trigger the provisioning of the managed network when creating a workspace with the managed network enabled, or else it does nothing.
-- `az ml capability-host`
-  - Added create operation.
-  - Added get operation.
-  - Added delete operation.
+  - Added `--provision-network-now` property to trigger the provisioning of the managed network when creating a workspace with the managed network enabled, or else it does nothing
 
 ## 2024-09-18
 


### PR DESCRIPTION
New version v2,36.0 of SDK CLI v2 is releasing on 12th March. I have updated the release notes for it. Also updated the release notes for 2.34 version which was not consistent with release notes in the SDK CLIv2 repo