### PR TITLE
Fixing example to match current syntax

### DIFF
--- a/articles/ai-services/openai/concepts/use-your-data.md
+++ b/articles/ai-services/openai/concepts/use-your-data.md
@@ -563,7 +563,7 @@ You can send a streaming request using the `stream` parameter, allowing data to 
 ```json
 {
     "stream": true,
-    "dataSources": [
+    "data_sources": [
         {
             "type": "AzureCognitiveSearch",
             "parameters": {


### PR DESCRIPTION
Ran into an issue when hitting this endpoint with "dataSources" was causing failures and saying that the correct field was "data_sources". After switching fields, the app started working