### PR TITLE
add additional instructions for troubleshooting extension manager OOM kill issue

### DIFF
--- a/articles/machine-learning/how-to-troubleshoot-kubernetes-extension.md
+++ b/articles/machine-learning/how-to-troubleshoot-kubernetes-extension.md
@@ -79,13 +79,25 @@ When you request support, we recommend that you run the following command and se
 kubectl logs healthcheck -n azureml
 ```
 ## Extension-operator pod in azure-arc/kube-system namespace is crashing due to OOMKill 
-This issue happens if the extension's helm chart size is large and there are multiple Helm releases on the cluster. Here is a sample script to help clean up the helm history on the cluster: 
+This issue occurs when the extension's Helm chart size is large and there are multiple Helm releases on the cluster.
+To check the Helm history of the Azure ML extension, use the following commands:
+```
+# Check if there is a release of the Azure ML extension Helm chart installed on the cluster
+# Note: The default namespace for the extension is usually 'azureml'. If you specified a different namespace during installation, replace 'azureml' with your namespace.
+helm list -n azureml
+
+# Get helm history 
+# Note: <release-name> can be retrieved from the output of the previous command
+helm history -n azureml <release-name>
+```
+There is a Helm history limit of 10 revisions, but this limit applies only to revisions in a non-transient state.
+If you see multiple revisions in a pending-rollback or pending-upgrade state in the Helm history output, run the script below to clean up the Helm history on the cluster:
 ```
 #!/bin/bash
 
 # Set release name and namespace
-RELEASE_NAME=$1
-NAMESPACE=$2
+RELEASE_NAME=$1 # release_name is the name of the azure ml extension helm release 
+NAMESPACE=$2 # namespace is the azure ml extension's namespace. Default value is azureml 
 
 # Validate input
 if [[ -z "$RELEASE_NAME" || -z "$NAMESPACE" ]]; then
@@ -124,7 +136,7 @@ How to run the script:
 ```
 chmod +x delete_stuck_helm_secrets.sh
 
-./delete_stuck_helm_secrets.sh my-release my-namespace
+./delete_stuck_helm_secrets.sh <release_name> <extension_namespace>
 ```
 
 ### Error Code of HealthCheck 


### PR DESCRIPTION
Adds steps on how users can get the extension release name and the extension release namespace, and verify whether there are multiple helm revisions stuck in pending state.