### PR TITLE
Setting correct parameter name for ImageContentItem (image -> image_url)

### DIFF
--- a/articles/ai-foundry/model-inference/includes/use-chat-multi-modal/python.md
+++ b/articles/ai-foundry/model-inference/includes/use-chat-multi-modal/python.md
@@ -105,7 +105,7 @@ response = client.complete(
         SystemMessage("You are a helpful assistant that can generate responses based on images."),
         UserMessage(content=[
             TextContentItem(text="Which conclusion can be extracted from the following chart?"),
-            ImageContentItem(image=ImageUrl(url=data_url))
+            ImageContentItem(image_url=ImageUrl(url=data_url))
         ]),
     ],
     temperature=1,


### PR DESCRIPTION
This pull request includes a change to the `articles/ai-foundry/model-inference/includes/use-chat-multi-modal/python.md` file to correct the parameter name in the `ImageContentItem` constructor.

* [`articles/ai-foundry/model-inference/includes/use-chat-multi-modal/python.md`](diffhunk://#diff-ad855663e0cfe0724eb4411447dbb0b8fbeeb55cce92e90e2aae5be0d809f88dL108-R108): Changed the parameter name from `image` to `image_url` in the `ImageContentItem` constructor.Ref: Azure AI Inference Python SDK docs: https://learn.microsoft.com/en-us/python/api/azure-ai-inference/azure.ai.inference.models.imagecontentitem?view=azure-python-preview#variables