### PR TITLE
Added mandatory role detail to be able to do this quickstart tutorial

### DIFF
--- a/articles/ai-services/language-service/custom-text-classification/includes/quickstarts/language-studio.md
+++ b/articles/ai-services/language-service/custom-text-classification/includes/quickstarts/language-studio.md
@@ -23,6 +23,8 @@ Before you can use custom text classification, you'll need to create an Azure AI
 > To quickly get started, we recommend creating a new Azure AI Language resource using the steps provided in this article. Using the steps in this article will let you create the Language resource and storage account at the same time, which is easier than doing it later.
 >
 > If you have a [pre-existing resource](../../how-to/create-project.md#using-a-pre-existing-language-resource) that you'd like to use, you will need to connect it to storage account.
+>
+> Adding the role **Storage Blob Data Contributor** is essential for interacting with *any resource* that utilizes the storage account
 
 [!INCLUDE [create a new resource from the Azure portal](../resource-creation-azure-portal.md)]
     

--- a/articles/ai-services/language-service/custom-text-classification/includes/quickstarts/language-studio.md
+++ b/articles/ai-services/language-service/custom-text-classification/includes/quickstarts/language-studio.md
@@ -24,7 +24,7 @@ Before you can use custom text classification, you'll need to create an Azure AI
 >
 > If you have a [pre-existing resource](../../how-to/create-project.md#using-a-pre-existing-language-resource) that you'd like to use, you will need to connect it to storage account.
 >
-> Adding the role **Storage Blob Data Contributor** is essential for interacting with *any resource* that utilizes the storage account
+> Adding the role **Storage Blob Data Contributor** is essential for interacting with *any resource* that utilizes the storage account.
 
 [!INCLUDE [create a new resource from the Azure portal](../resource-creation-azure-portal.md)]
     


### PR DESCRIPTION
Some clients have shared that they were unable to complete the tutorial. As the Storage Blob Data Contributor role is mandatory to be able to use the storage account I believe it´s necessary to add this detail to the documentation.
I´ve checked this note is added in other pages, but not here. As it is a requirement to be able to complete the tutorial, I believe it´s important to add it here as well.
Thank you.