### PR TITLE
wrong python import in EntraID example

### DIFF
--- a/articles/ai-foundry/model-inference/includes/use-embeddings/python.md
+++ b/articles/ai-foundry/model-inference/includes/use-embeddings/python.md
@@ -52,7 +52,7 @@ If you have configured the resource to with **Microsoft Entra ID** support, you 
 ```python
 import os
 from azure.ai.inference import EmbeddingsClient
-from azure.core.credentials import AzureKeyCredential
+from azure.identity import DefaultAzureCredential
 
 model = EmbeddingsClient(
     endpoint=os.environ["AZURE_INFERENCE_ENDPOINT"],


### PR DESCRIPTION
the import is wrong, DefaultAzureCredential is from azure.identity. 

![image](https://github.com/user-attachments/assets/683a0c20-58e0-47dc-a09d-81d821654f2f)

noticed the issue while looking at this post: https://stackoverflow.com/questions/79604947/issues-connecting-to-azure-ai-foundry-models-using-ms-entra-id/79606750#79606750