### PR TITLE
Update use-your-data-quickstart.m to adjust pre-reqs

### DIFF
--- a/articles/ai-services/openai/use-your-data-quickstart.md
+++ b/articles/ai-services/openai/use-your-data-quickstart.md
@@ -22,11 +22,7 @@ In this quickstart, you can use your own data with Azure OpenAI models. Using Az
 ## Prerequisites
 
 The following resources: 
-- [Azure OpenAI](https://portal.azure.com/#create/Microsoft.CognitiveServicesOpenAI)
-- [Azure Blob Storage](https://portal.azure.com/#create/Microsoft.StorageAccount-ARM)
-- [Azure AI Search](https://portal.azure.com/#create/Microsoft.Search)
-- An [Azure OpenAI resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesOpenAI) deployed in a [supported region and with a supported model](./concepts/use-your-data.md#regional-availability-and-model-support).
-    - Be sure that you're assigned at least the [Cognitive Services Contributor](./how-to/role-based-access-control.md#cognitive-services-contributor) role for the Azure OpenAI resource.
+- 
 - Download the example data from [GitHub](https://github.com/Azure-Samples/cognitive-services-sample-data-files/blob/master/openai/contoso_benefits_document_example.pdf) if you don't have your own data.
 
 
@@ -41,11 +37,7 @@ The following resources:
 ## Prerequisites
 
 The following resources: 
-- [Azure OpenAI](https://portal.azure.com/#create/Microsoft.CognitiveServicesOpenAI)
-- [Azure Blob Storage](https://portal.azure.com/#create/Microsoft.StorageAccount-ARM)
-- [Azure AI Search](https://portal.azure.com/#create/Microsoft.Search)
-- An [Azure OpenAI resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesOpenAI) deployed in a [supported region and with a supported model](./concepts/use-your-data.md#regional-availability-and-model-support).
-    - Be sure that you're assigned at least the [Cognitive Services Contributor](./how-to/role-based-access-control.md#cognitive-services-contributor) role for the Azure OpenAI resource.
+- An Azure subscription - <a href="https://azure.microsoft.com/free/cognitive-services" target="_blank">Create one for free</a>.
 - Download the example data from [GitHub](https://github.com/Azure-Samples/cognitive-services-sample-data-files/blob/master/openai/contoso_benefits_document_example.pdf) if you don't have your own data.
 - The [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 


### PR DESCRIPTION
Adjusting the pre-reqs for the AI Foundry preferred programming language since we see better results when getting directly into the chat playground as quickly as possible where they can set up those services. Additionally, the current pre-reqs link to Azure OpenAI service twice, which causes confusion