### PR TITLE
Fix typo in built-in role name: "Contributer" → "Contributor"

### DIFF
--- a/articles/ai-services/language-service/question-answering/how-to/network-isolation.md
+++ b/articles/ai-services/language-service/question-answering/how-to/network-isolation.md
@@ -21,12 +21,12 @@ Private endpoints are provided by [Azure Private Link](/azure/private-link/priva
 
 ## Steps to enable private endpoint
 
-1. Assign *Contributer* role to language resource (Depending on the context this may appear as a Text Analytics resource) in the Azure Search Service instance. This operation requires *Owner* access to the subscription. Go to Identity tab in the service resource to get the identity.
+1. Assign *Contributor* role to language resource (Depending on the context this may appear as a Text Analytics resource) in the Azure Search Service instance. This operation requires *Owner* access to the subscription. Go to Identity tab in the service resource to get the identity.
 
 > [!div class="mx-imgBorder"]
 > ![Text Analytics Identity](../../../QnAMaker/media/qnamaker-reference-private-endpoints/private-endpoints-identity.png)
 
-2. Add the above identity as *Contributer* by going to Azure Search Service IAM tab.
+2. Add the above identity as *Contributor* by going to Azure Search Service IAM tab.
 
 ![Managed service IAM](../../../QnAMaker/media/qnamaker-reference-private-endpoints/private-endpoint-access-control.png)
 

--- a/articles/ai-services/qnamaker/reference-private-endpoint.md
+++ b/articles/ai-services/qnamaker/reference-private-endpoint.md
@@ -22,12 +22,12 @@ Private endpoints are provided by [Azure Private Link](/azure/private-link/priva
 > * A [Text Analytics resource](https://portal.azure.com/?quickstart=true#create/Microsoft.CognitiveServicesTextAnalytics) (with Custom question answering feature) created in the Azure portal. Remember your Microsoft Entra ID, Subscription, Text Analytics resource name you selected when you created the resource.
 
 ## Steps to enable private endpoint
-1. Assign *Contributer* role to Text Analytics service in the Azure Search Service instance. This operation requires *Owner* access to the subscription. Go to Identity tab in the service resource to get the identity.
+1. Assign *Contributor* role to Text Analytics service in the Azure Search Service instance. This operation requires *Owner* access to the subscription. Go to Identity tab in the service resource to get the identity.
 
 > [!div class="mx-imgBorder"]
 > ![Text Analytics Identity](../qnamaker/media/qnamaker-reference-private-endpoints/private-endpoints-identity.png)
 
-1. Add the above identity as *Contributer* by going to Azure Search Service IAM tab.
+1. Add the above identity as *Contributor* by going to Azure Search Service IAM tab.
 
 ![Managed service IAM](../qnamaker/media/qnamaker-reference-private-endpoints/private-endpoint-access-control.png)
 


### PR DESCRIPTION
### Summary

This PR fixes a small typo in the documentation where the built-in role "Contributor" was incorrectly spelled as "Contributer".

### Change Details

- Replaced "Contributer" with the correct spelling "Contributor" in a sentence discussing the use of built-in roles.

### Reason

Accurate spelling of role names is essential for user clarity and aligns with official Azure RBAC terminology. This change helps avoid potential confusion for readers or users referencing this documentation.

### Reference

- [Azure built-in roles documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles)