### PR TITLE
Adding OS to ai-foundry get-started.md

### DIFF
--- a/articles/ai-foundry/foundry-local/get-started.md
+++ b/articles/ai-foundry/foundry-local/get-started.md
@@ -6,7 +6,7 @@ manager: scottpolly
 keywords: Azure AI services, cognitive, AI models, local inference
 ms.service: azure-ai-foundry
 ms.topic: quickstart
-ms.date: 05/20/2025
+ms.date: 05/23/2025
 ms.reviewer: samkemp
 ms.author: samkemp
 author: samuel100
@@ -24,7 +24,7 @@ This guide walks you through setting up Foundry Local to run AI models on your d
 
 Your system must meet the following requirements to run Foundry Local:
 
-- **Operating System**: Windows 10 (x64), Windows 11 (x64/ARM), macOS.
+- **Operating System**: Windows 10 (x64), Windows 11 (x64/ARM), Windows Server 2025, macOS.
 - **Hardware**: Minimum 8GB RAM, 3GB free disk space. Recommended 16GB RAM, 15GB free disk space.
 - **Network**: Internet connection for initial model download (optional for offline use)
 - **Acceleration (optional)**: NVIDIA GPU (2,000 series or newer), AMD GPU (6,000 series or newer), Qualcomm Snapdragon X Elite (8GB or more of memory), or Apple silicon.


### PR DESCRIPTION
This pull request updates the `get-started.md` file for Foundry Local to reflect new operating system support and a revised publication date.

Content updates:

* Updated the `ms.date` metadata to reflect a new publication date of 05/23/2025. (`articles/ai-foundry/foundry-local/get-started.md`, [articles/ai-foundry/foundry-local/get-started.mdL9-R9](diffhunk://#diff-1622b543c90eec10e17f433c87b2abc63e2e16f2ada72b22a595ccab8031b58bL9-R9))
* Added support for Windows Server 2025 in the system requirements section under "Operating System." (`articles/ai-foundry/foundry-local/get-started.md`, [articles/ai-foundry/foundry-local/get-started.mdL27-R27](diffhunk://#diff-1622b543c90eec10e17f433c87b2abc63e2e16f2ada72b22a595ccab8031b58bL27-R27))