### PR TITLE
Update how-to-mlflow-batch.md

### DIFF
--- a/articles/machine-learning/how-to-mlflow-batch.md
+++ b/articles/machine-learning/how-to-mlflow-batch.md
@@ -235,6 +235,8 @@ To test your endpoint, you use a sample of unlabeled data located in this reposi
    # [Python](#tab/python)
 
    [!INCLUDE [batch-endpoint-invoke-inputs-sdk](includes/batch-endpoint-invoke-inputs-sdk.md)]
+
+   Refer to this notebook for the full code: [Heart Classifier MLflow Batch Notebook](https://github.com/Azure/azureml-examples/blob/main/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb). 
    
    [!notebook-python[] (~/azureml-examples-main/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb?name=start_batch_scoring_job)]
 
@@ -279,6 +281,8 @@ To download the predictions, use the following command:
 :::code language="azurecli" source="~/azureml-examples-main/cli/endpoints/batch/deploy-models/heart-classifier-mlflow/deploy-and-run.sh" ID="download_outputs" :::
 
 # [Python](#tab/python)
+
+Refer to this notebook for the full code: [Heart Classifier MLflow Batch Notebook](https://github.com/Azure/azureml-examples/blob/main/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb). 
 
 To download the predictions, use the following code:
 


### PR DESCRIPTION
Added -> Refer to this notebook for the full code: [Heart Classifier MLflow Batch Notebook](https://github.com/Azure/azureml-examples/blob/main/sdk/python/endpoints/batch/deploy-models/heart-classifier-mlflow/mlflow-for-batch-tabular.ipynb).

The Documentation doesn't cover all steps as in the notebook. Consider it's a good idea to refer to the notebook for the full code.

For example, it refers to 

```job = ml_client.batch_endpoints.invoke(endpoint_name=endpoint.name, input=input)``` but `input` is not defined in this documentation, only in the notebook. It has to be of type Input().

Or

```ml_client.jobs.download(name=scoring_job.name, download_path=".", output_name="score")``` refers to a certain `scoring_job` that has not been defined in this documentation. 

In order to get the full picture, I believe the specific reference to the notebook is useful. 