### PR TITLE
Fix grammar in about-reasoning.md (“models produces” → “models produce”) and propagate change to referencing articles

### DIFF
--- a/articles/ai-foundry/model-inference/includes/use-chat-reasoning/about-reasoning.md
+++ b/articles/ai-foundry/model-inference/includes/use-chat-reasoning/about-reasoning.md
@@ -9,7 +9,7 @@ author: santiagxf
 
 ## Reasoning models
 
-Reasoning models can reach higher levels of performance in domains like math, coding, science, strategy, and logistics. The way these models produces outputs is by explicitly using chain of thought to explore all possible paths before generating an answer. They verify their answers as they produce them which helps them to arrive to better more accurate conclusions. This means that reasoning models may require less context in prompting in order to produce effective results. 
+Reasoning models can reach higher levels of performance in domains like math, coding, science, strategy, and logistics. The way these models produce outputs is by explicitly using chain of thought to explore all possible paths before generating an answer. They verify their answers as they produce them which helps them to arrive to better more accurate conclusions. This means that reasoning models may require less context in prompting in order to produce effective results. 
 
 Such way of scaling model's performance is referred as *inference compute time* as it trades performance against higher latency and cost. It contrasts to other approaches that scale through *training compute time*. 
 


### PR DESCRIPTION
Why:
• The shared include file about-reasoning.md contains a subject/verb disagreement:
“The way these models **produces** outputs…”
This text surfaces in multiple public docs (DeepSeek-R1 tutorial and “How to use reasoning models” guide).
• The typo affects readability and appears in every article that includes the file.

What was changed:
Edited about-reasoning.md
• “The way these models **produce** outputs …” – corrected verb agreement.

No structural changes; all pages that reference the include automatically receive the fix:
• tutorials/get-started-deepseek-r1.md
• how-to/use-chat-reasoning.md (and its language-filtered variants)

Impact:
• Removes a visible grammatical error from two Azure AI Foundry articles (and any future pages that reuse the include).
• No API, sample code, or UI changes; doc build remains intact.