### PR TITLE
Clarify Azure Function trigger support in agent integration

### DIFF
--- a/articles/ai-foundry/agents/how-to/tools/azure-functions.md
+++ b/articles/ai-foundry/agents/how-to/tools/azure-functions.md
@@ -14,10 +14,14 @@ ms.custom: azure-ai-agents
 
 # Use Azure Functions with Azure AI Foundry Agent Service
 
-The Azure AI Foundry Agent Service integrates with Azure Functions, enabling you to create intelligent, event-driven applications with minimal overhead. This combination allows AI-driven workflows to leverage the scalability and flexibility of serverless computing, making it easier to build and deploy solutions that respond to real-time events or complex workflows. 
- 
-Azure Functions provide support for triggers and bindings, which simplify how your AI Agents interact with external systems and services. Triggers determine when a function executes—such as an HTTP request, message from a queue, or a file upload to Azure Blob Storage and allows agents to act dynamically based on incoming events. 
- 
+The Azure AI Foundry Agent Service integrates with Azure Functions, enabling you to create intelligent, event-driven applications with minimal overhead. This combination allows AI-driven workflows to leverage the scalability and flexibility of serverless computing, making it easier to build and deploy solutions that respond to real-time events or complex workflows.
+
+Currently, direct integration with Azure Functions is only supported for functions triggered by Azure Storage Queues. Other trigger types, such as HTTP or Blob Storage, are not natively supported at this time.
+
+Azure Functions provide support for triggers and bindings, which simplify how your AI Agents interact with external systems and services. Triggers determine when a function executes—such as an HTTP request, message from a queue, or a file upload to Azure Blob Storage—and allow agents to act dynamically based on incoming events.
+
+For HTTP-triggered Azure Functions, integration is possible by describing the function through an OpenAPI specification and registering it as a callable tool in the agent configuration. Alternatively, you can implement a queue-based wrapper function that receives messages from the agent and internally invokes the HTTP logic, enabling the use of the existing queue-based integration.
+
 Meanwhile, bindings facilitate streamlined connections to input or output data sources, such as databases or APIs, without requiring extensive boilerplate code. For instance, you can configure a trigger to execute an Azure Function whenever a customer message is received in a chatbot and use output bindings to send a response via the Azure AI Agent.
 
 ### Supported models


### PR DESCRIPTION
This update clarifies that Azure AI Foundry currently supports direct integration only for Azure Functions triggered by Azure Storage Queues.

The previous version of the documentation suggested that multiple trigger types—including HTTP and Blob—were supported, which led to confusion and unnecessary time spent by developers trying to integrate unsupported scenarios.

This clarification aims to prevent future misunderstandings, save development time, and set the correct expectations. It also offers practical guidance for working with HTTP-triggered functions using either OpenAPI-based tool registration or a queue-triggered wrapper pattern, so developers can still integrate their HTTP logic effectively.

Improving this section will help reduce friction and frustration for teams evaluating Azure Functions as tools for agent workflows.