### PR TITLE
Fix articles/machine-learning/how-to-deploy-kubernetes-extension.md

### DIFF
--- a/articles/machine-learning/how-to-deploy-kubernetes-extension.md
+++ b/articles/machine-learning/how-to-deploy-kubernetes-extension.md
@@ -100,7 +100,7 @@ We list four typical extension deployment scenarios for reference. To deploy ext
 
    For Azure Machine Learning extension deployment on AKS cluster, make sure to specify `managedClusters` value for `--cluster-type` parameter. Run the following Azure CLI command to deploy Azure Machine Learning extension:
    ```azurecli
-   az k8s-extension create --name <extension-name> --extension-type Microsoft.AzureML.Kubernetes --config enableTraining=True enableInference=True inferenceRouterServiceType=LoadBalancer allowInsecureConnections=True InferenceRouterHA=False --cluster-type managedClusters --cluster-name <your-AKS-cluster-name> --resource-group <your-RG-name> --scope cluster
+   az k8s-extension create --name <extension-name> --extension-type Microsoft.AzureML.Kubernetes --config enableTraining=True enableInference=True inferenceRouterServiceType=LoadBalancer allowInsecureConnections=True inferenceRouterHA=False --cluster-type managedClusters --cluster-name <your-AKS-cluster-name> --resource-group <your-RG-name> --scope cluster
    ```
 
 - **Use Arc Kubernetes cluster outside of Azure for a quick proof of concept, to run training jobs only**


### PR DESCRIPTION
The command for `az k8s-extension create` shows the config setting for `InferenceRouterHA=False` when it should be `inferenceRouterHA=False`.  This causes the `azureml-fe-v2` deployment to attempt to deploy three replicas. In a scenario where the user has less than three nodes, the extension deployment will fail.