### PR TITLE
Sample Code Syntax Error in azure-openai-graders.md

### DIFF
--- a/articles/ai-foundry/concepts/evaluation-evaluators/azure-openai-graders.md
+++ b/articles/ai-foundry/concepts/evaluation-evaluators/azure-openai-graders.md
@@ -31,8 +31,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 model_config = AzureOpenAIModelConfiguration(
-    azure_endpoint=os.environ["AZURE_ENDPOINT"],
-    api_key=os.environ.get["AZURE_API_KEY"],
+    azure_endpoint=os.environ.get("AZURE_ENDPOINT"),
+    api_key=os.environ.get("AZURE_API_KEY"),
     azure_deployment=os.environ.get("AZURE_DEPLOYMENT_NAME"),
     api_version=os.environ.get("AZURE_API_VERSION"),
 )
@@ -193,7 +193,7 @@ sim_grader_evaluation = evaluate(
         "similarity": sim_grader
     },
 )
-evaluation
+sim_grader_evaluation
 ```
 
 ### Text similarity output


### PR DESCRIPTION
error on model_config. The way os.environ , wrong and inconsistant, lead to error.  
```
    azure_endpoint=os.environ["AZURE_ENDPOINT"],
    api_key=os.environ.get["AZURE_API_KEY"], #<== Error! Not subscribable.
    azure_deployment=os.environ.get("AZURE_DEPLOYMENT_NAME"),
    api_version=os.environ.get("AZURE_API_VERSION"),
```
___
another one is presume run in notebook, it print out the result, but it's using the accessing the wrong variable. 
```
sim_grader_evaluation = evaluate(
    data=data_file_name,
    evaluators={
        "similarity": sim_grader
    },
)
evaluation # <== wrong , it should be sim_grader_evaluation 
```
___

**lastly, the data.jsonl mentioned is a JSONL, but given example is not a JSONL format.**