### PR TITLE
Update keyless-connections.md

### DIFF
--- a/articles/search/keyless-connections.md
+++ b/articles/search/keyless-connections.md
@@ -184,7 +184,7 @@ from azure.search.documents import SearchClient
 from azure.identity import DefaultAzureCredential, AzureAuthorityHosts
 
 # Azure Public Cloud
-audience = "https://search.windows.net"
+audience = "[https://search.windows.net](https://search.azure.com)"
 authority = AzureAuthorityHosts.AZURE_PUBLIC_CLOUD
 
 service_endpoint = os.environ["AZURE_SEARCH_ENDPOINT"]


### PR DESCRIPTION
The correct audience for Azure Cognitive Search with RBAC is https://search.azure.com.

Old SDKs or legacy code might use .windows.net, but for Azure AD/RBAC, it’s .azure.com.