### PR TITLE
Update responses.md typo in reference link anchor

### DIFF
--- a/articles/ai-foundry/openai/how-to/responses.md
+++ b/articles/ai-foundry/openai/how-to/responses.md
@@ -70,7 +70,7 @@ Not every model is available in the regions supported by the responses API. Chec
 
 ### Reference documentation
 
-- [Responses API reference documentation](/azure/ai-services/openai/reference-preview-latest?#responses-api---create)
+- [Responses API reference documentation](/azure/ai-services/openai/reference-preview-latest?#create-response)
 
 ## Getting started with the responses API
 


### PR DESCRIPTION
existing link https://learn.microsoft.com/en-us/azure/ai-services/openai/reference-preview-latest?#responses-api---create hits a redirect to https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference-preview-latest#responses-api---create where anchor "#responses-api---create" doesn't exist.  #create-response seems to be the (new) valid target