### PR TITLE
Update provisioned-migration.md for "self-service migration" only

### DIFF
--- a/articles/ai-foundry/openai/concepts/provisioned-migration.md
+++ b/articles/ai-foundry/openai/concepts/provisioned-migration.md
@@ -206,9 +206,7 @@ Customers that have commitments today can continue to use them at least until th
 
 ## Migrating existing resources off commitments
 
-Existing customers can choose to migrate their existing resources from the Commitment to the Hourly/Reservation payment model to benefit from the ability to deploy the latest models, or to consolidate discounting for diverse deployments under a single reservation.
-
-Two approaches are available for customers to migrate resources using the Commitment model to the Hourly/Reservation model.
+Existing customers can choose to migrate their existing resources from the Commitment to the Hourly/Reservation payment model to benefit from the ability to deploy the latest models, or to consolidate discounting for diverse deployments under a single reservation, using a self-service approach.
 
 ### Self-service migration
 


### PR DESCRIPTION
There used to be two options for Migrating from Commitments to Reservation : self service migration and managed migration.

Managed Migration is not available anymore (confirmed with PM Amar Badal), and its block was removed from doc a few weeks ago.

However we still have a sentence that relies on those two options "Two approaches are available ..." creating expectations for a second one that never comes (or mixing it with next chapter of migration to Global)

Removed that sentence + improved transition from previous paragraph.