### PR TITLE
AI Foundry - update IaC instructions

### DIFF
--- a/articles/ai-foundry/agents/how-to/virtual-networks.md
+++ b/articles/ai-foundry/agents/how-to/virtual-networks.md
@@ -69,79 +69,26 @@ For customers without an existing virtual network, the Standard Setup with Priva
 
 ## Configure a new network-secured environment 
 
-**Network secured setup**: Agents use customer-owned, single-tenant search and storage resources. With this setup, you have full control and visibility over these resources, but you incur costs based on your usage. The following bicep template provides:
+> [!NOTE]
+> Programmatic deployment is the only way to deploy a network secured environment for Azure AI Foundry Agent Service, it is currently not possibly on Azure Portal.
 
-* An account and project are created. 
-* A gpt-4o model is deployed. 
+> [!NOTE]
+> If you want to delete your Foundry resource and Standard Agent with secured network set-up, delete your AI Foundry resource and virtual network last. Before deleting the virtual network, ensure to delete and [purge](../../../ai-services/recover-purge-resources.md#purge-a-deleted-resource) your AI Foundry resource.
+
+> [!NOTE]
+> In the Standard Setup, agents use customer-owned, single-tenant resources. You have full control and visibility over these resources, but you incur costs based on your usage.
+
+You can deploy and customize the Standard Setup with Private Networking using either Bicep or Terraform. The provided samples allow you to bring your own virtual network and customize the deployment to meet your specific requirements:
+
+* Foundry account and Foundry project are created.
+* A gpt-4o model is deployed.
 * Azure resources for storing customer data — Azure Storage, Azure Cosmos DB, and Azure AI Search — are automatically created if existing resources are not provided. 
-* These resources are connected to your project to store files, threads, and vector data. 
-* A Microsoft-managed key vault is used by default. 
+* These resources are connected to your project to store files, threads, and vector data.
+* Microsoft-managed encryption keys for Storage Account and Cognitive Account (AI Foundry) are used by default.
 
+- **Bicep templates**: follow instructions in [this sample from GitHub](https://github.com/azure-ai-foundry/foundry-samples/tree/main/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup).
 
-### Manually deploy the bicep template
-
-> [!NOTE]
-> Using the Bicep template is the only way to deploy a network secured environment for Azure AI Foundry Agent Service.
-
-1. To deploy and customize the bicep templates, [download the template from GitHub](https://github.com/azure-ai-foundry/foundry-samples/tree/main/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup). Download the following from the `private-network-standard-agent-setup` folder:
-    1. `main-create.bicep`
-    1. `azuredeploy.parameters.json`
-    1. `modules-network-secured folder`
-1. To authenticate to your Azure subscription from the Azure CLI, use the following command: 
-
-    ```console
-    az login
-    ```
-
-1. Create a resource group:
-
-    ```console
-    az group create --name {my_resource_group} --location eastus
-    ```
-
-    Make sure you have the Azure AI Developer role for the resource group you created. 
-
-1. Using the resource group you created in the previous step and one of the template files (`private-network-standard-agent-setup`), run one of the following commands: 
-
-    1. To use default resource names, run:
-
-        ```console
-        az deployment group create --resource-group {my_resource_group} --template-file main-create.bicep
-        ```
-
-1. Run the CheckCapabilityHostReadiness.ps1 and edit the command to add your subscription ID, resource group name, and your newly deployed AI Services account resource name.
-   
-   ```
-   .\CheckCapabilityHostReadiness.ps1 -subscriptionId "<your-sub-id>" -resourcegroup "<new-rg-name>" -accountname "<your-aiservices-name>"
-   ```
-   
-   If you don't want to run the PowerShell script, you can run a bash script instead, from the file CheckCapabilityHostReadiness.sh. Run the following two commands:
-   
-      ```
-      chmod +x CheckCapabilityHostReadiness.sh
-      ./CheckCapabilityHostReadiness.sh "<your-sub-id>" "<new-rg-name>" "<your-aiservices-name>"
-      ```
-      
-1. Deploy the main-project-caphost-create.bicep
-   
-   ```
-   az deployment group create --resource-group <new-rg-name> --template-file main-project-caphost-create.bicep
-   ```
-   
-   After running this script, you're required to input the following values:
-   
-   ```
-   Please provide string value for 'accountName' (? for help): <your-account-name>
-   Please provide string value for 'projectName' (? for help): <your-project-name>
-   Please provide string value for 'aiSearchName' (? for help): <your-search-name>
-   Please provide string value for 'azureStorageName' (? for help): <your-storage-name>
-   Please provide string value for 'cosmosDBName' (? for help): <your-cosmosdb-name>
-   ```
-
-For more details, see the [README](https://github.com/azure-ai-foundry/foundry-samples/tree/main/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup).
-
-> [!NOTE]
-> If you want to delete your Foundry resource and Standard Agent with secured network set-up, delete your AI Foundry resource and virtual network last. Before deleting the virutal network, ensure to delete and purge your AI Foundry resource. Navigate to __Manage deleted resources__, then select your subscription and the Foundry resource you would like to purge. 
+- **Terraform configuration**: follow instructions in [this sample from GitHub](https://github.com/azure-ai-foundry/foundry-samples/tree/main/samples/microsoft/infrastructure-setup-terraform/15b-private-network-standard-agent-setup-byovnet).
 
 ## Deep Dive Standard Setup with Private Networking Template
 When you use the Standard Setup with Private Networking Agent Template, the following will automatically be provisioned, unless you bring your own: 


### PR DESCRIPTION
The documented instructions for deployment of AI Foundry with private networking became outdated after the recent changes to the Bicep templates they reference.

I suggest we:

- Use the deployment instructions in the `foundry-samples` repository as the source of truth; 
- Document that Terraform samples are also available.