### PR TITLE
Improving RBAC roles needed for running the quickstart end to end

### DIFF
--- a/articles/ai-foundry/agents/includes/quickstart-foundry.md
+++ b/articles/ai-foundry/agents/includes/quickstart-foundry.md
@@ -9,7 +9,7 @@ ms.date: 07/11/2025
 
 ## Prerequisites
 - An Azure subscription - <a href="https://azure.microsoft.com/free/cognitive-services" target="_blank">Create one for free</a>.
-- Ensure that the individual creating the account and project has the **Azure AI Account Owner** role at the subscription scope, which will grant you the necessary permissions for creating the agent and project
+- Ensure that the individual creating the account and project has the **Azure AI Account Owner** role at the subscription scope, which will grant the necessary permissions for creating the project
     * Alternatively, having the **Contributor** or **Cognitive Services Contributor** role at the subscription level will allow the creation of the project
 - Once the project is created, ensure that the individual creating the agent within the project has the **Azure AI User** role at the project level
 

--- a/articles/ai-foundry/agents/includes/quickstart-foundry.md
+++ b/articles/ai-foundry/agents/includes/quickstart-foundry.md
@@ -9,8 +9,8 @@ ms.date: 07/11/2025
 
 ## Prerequisites
 - An Azure subscription - <a href="https://azure.microsoft.com/free/cognitive-services" target="_blank">Create one for free</a>.
-- Ensure that the individual creating the account and project has the **Azure AI Account Owner** role at the subscription scope
-    * Alternatively, having the **Contributor** or **Cognitive Services Contributor** role at the subscription level also satisfies this requirement.
+- Ensure that the individual creating the account and project has the **Azure AI Account Owner** role at the subscription scope, which will grant you the necessary permissions for creating the agent and project
+    * Alternatively, having the **Contributor** or **Cognitive Services Contributor** role at the subscription level will allow the creation of the project, and **Azure AI User** at the project level will allow the creation of the agent.
 
 
 > [!IMPORTANT]

--- a/articles/ai-foundry/agents/includes/quickstart-foundry.md
+++ b/articles/ai-foundry/agents/includes/quickstart-foundry.md
@@ -10,7 +10,8 @@ ms.date: 07/11/2025
 ## Prerequisites
 - An Azure subscription - <a href="https://azure.microsoft.com/free/cognitive-services" target="_blank">Create one for free</a>.
 - Ensure that the individual creating the account and project has the **Azure AI Account Owner** role at the subscription scope, which will grant you the necessary permissions for creating the agent and project
-    * Alternatively, having the **Contributor** or **Cognitive Services Contributor** role at the subscription level will allow the creation of the project, and **Azure AI User** at the project level will allow the creation of the agent.
+    * Alternatively, having the **Contributor** or **Cognitive Services Contributor** role at the subscription level will allow the creation of the project
+- Once the project is created, ensure that the individual creating the agent within the project has the **Azure AI User** at the project level
 
 
 > [!IMPORTANT]

--- a/articles/ai-foundry/agents/includes/quickstart-foundry.md
+++ b/articles/ai-foundry/agents/includes/quickstart-foundry.md
@@ -11,7 +11,7 @@ ms.date: 07/11/2025
 - An Azure subscription - <a href="https://azure.microsoft.com/free/cognitive-services" target="_blank">Create one for free</a>.
 - Ensure that the individual creating the account and project has the **Azure AI Account Owner** role at the subscription scope, which will grant you the necessary permissions for creating the agent and project
     * Alternatively, having the **Contributor** or **Cognitive Services Contributor** role at the subscription level will allow the creation of the project
-- Once the project is created, ensure that the individual creating the agent within the project has the **Azure AI User** at the project level
+- Once the project is created, ensure that the individual creating the agent within the project has the **Azure AI User** role at the project level
 
 
 > [!IMPORTANT]


### PR DESCRIPTION
If the individual running the quickstart is only **Contributor** or **Cognitive Services Contributor**, they'll be able to create the project but not the agent.

At the end of this very same document there's a note saying "Hey, if you don't have permissions make sure you have **Azure AI User**", but that note is a bit hidden (although it might be useful if you reach that part of the quickstart and didn't pay attention to prerequisites)

I'm adding a bit more clarity on what's needed in the prerequisites section