### PR TITLE
Fixed YAML indentation in install-run.md

### DIFF
--- a/articles/ai-services/document-intelligence/containers/install-run.md
+++ b/articles/ai-services/document-intelligence/containers/install-run.md
@@ -283,7 +283,7 @@ services:
     container_name: azure-cognitive-service-read
     image: mcr.microsoft.com/azure-cognitive-services/form-recognizer/read-3.1
     environment:
-      - EULA=accept
+        - EULA=accept
         - billing={FORM_RECOGNIZER_ENDPOINT_URI}
         - apiKey={FORM_RECOGNIZER_KEY}
 ```
@@ -671,7 +671,7 @@ services:
     container_name: azure-cognitive-service-read
     image: mcr.microsoft.com/azure-cognitive-services/form-recognizer/read-3.1
     environment:
-      - EULA=accept
+        - EULA=accept
         - billing={FORM_RECOGNIZER_ENDPOINT_URI}
         - apiKey={FORM_RECOGNIZER_KEY}
 ```


### PR DESCRIPTION
Fixed YAML indentation issues in two locations.

### Before

``` yaml
    environment:
      - EULA=accept
        - billing={FORM_RECOGNIZER_ENDPOINT_URI}
        - apiKey={FORM_RECOGNIZER_KEY}
```

### After

``` yaml
    environment:
        - EULA=accept
        - billing={FORM_RECOGNIZER_ENDPOINT_URI}
        - apiKey={FORM_RECOGNIZER_KEY}
```