### PR TITLE
Agents in hub-based projects is currently in preview

### DIFF
--- a/articles/ai-foundry/agents/how-to/metrics.md
+++ b/articles/ai-foundry/agents/how-to/metrics.md
@@ -15,6 +15,8 @@ ms.service: azure-ai-agent-service
 
 Monitoring is available for agents in a [standard agent setup](../concepts/standard-agent-setup.md).
 
+[!INCLUDE [Feature preview](https://github.com/MicrosoftDocs/azure-ai-docs/blob/main/articles/ai-foundry/openai/includes/preview-feature.md)]
+
 > [!IMPORTANT]
 > Monitoring support is currently limited to Azure AI Foundry hubs. Azure AI Foundry projects are not supported.
 


### PR DESCRIPTION
To avoid any confusion for all users, this document should clearly state at the beginning that the monitoring feature for Agents in hub-based projects (that has only preview Agents featre) is also a preview feature.
 
Background:
The metrics described in this document (titled "Monitor Azure AI Foundry **Agent** Service") are only applicable to **hub-based projects**.   Additionally, the Agents feature in hub-based projects is still in preview, as explained in the document below.  

- What is Azure AI Foundry? - Azure AI Foundry | Microsoft Learn https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-azure-ai-foundry#which-type-of-project-do-i-need

"Agents / Foundry Project（GA）/ hub based project (Preview only)"
<img width="703" height="390" alt="image" src="https://github.com/user-attachments/assets/0505ffe5-c1d2-437f-a461-2e85e591043a" />