### PR TITLE
Update trace-agents-sdk.md

### DIFF
--- a/articles/ai-foundry/how-to/develop/trace-agents-sdk.md
+++ b/articles/ai-foundry/how-to/develop/trace-agents-sdk.md
@@ -71,7 +71,7 @@ Next, retrieve the connection string from the Application Insights resource conn
 
 ```python
 from azure.monitor.opentelemetry import configure_azure_monitor
-connection_string = project_client.telemetry.get_connection_string()
+connection_string = project_client.telemetry.get_application_insights_connection_string()
 
 if not connection_string:
     print("Application Insights is not enabled. Enable by going to Tracing in your Azure AI Foundry project.")


### PR DESCRIPTION
### Updated telemetry documentation reference

Replaced incorrect usage of a non-existent method `get_connection_string()` with the correct `get_application_insights_connection_string()` when retrieving the Application Insights connection string.

---

#### Context

I initially followed the docs:

```python
project = AIProjectClient(
    credential=DefaultAzureCredential(),
    endpoint=os.getenv("AZURE_AI_FOUNDRY_ENDPOINT"),
)
tracer = trace.get_tracer(__name__)
connection_string = project.telemetry.get_connection_string()
configure_azure_monitor(connection_string=connection_string)
```

This resulted in the following error:
```
Traceback (most recent call last):  line 21, in <module>
    connection_string = project.telemetry.get_connection_string()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TelemetryOperations' object has no attribute 'get_connection_string'. Did you mean: '_connection_string'?
```

#### Investigation
I checked the source code of the SDK and found this in the TelemetryOperations class:

```python
class TelemetryOperations:
    """
    .. warning::
        **DO NOT** instantiate this class directly.

        Instead, you should access the following operations through
        :class:`~azure.ai.projects.AIProjectClient`'s
        :attr:`telemetry` attribute.
    """

    _connection_string: Optional[str] = None

    def __init__(self, outer_instance: "azure.ai.projects.AIProjectClient") -> None:  # type: ignore[name-defined]
        self._outer_instance = outer_instance

    @distributed_trace
    def get_application_insights_connection_string(self) -> str:  # pylint: disable=name-too-long
```

#### Resolution
Switching to the correct method resolved the issue:

```python
project = AIProjectClient(
    credential=DefaultAzureCredential(),
    endpoint=os.getenv("AZURE_AI_FOUNDRY_ENDPOINT"),
)

tracer = trace.get_tracer(__name__)

connection_string = project.telemetry.get_application_insights_connection_string()
configure_azure_monitor(connection_string=connection_string)
```
