### PR TITLE
Update trace-application.md

### DIFF
--- a/articles/ai-foundry/how-to/develop/trace-application.md
+++ b/articles/ai-foundry/how-to/develop/trace-application.md
@@ -95,7 +95,7 @@ When developing with the OpenAI SDK, you can instrument your code so traces are 
         endpoint="https://<your-resource>.services.ai.azure.com/api/projects/<your-project>",
     )
 
-    connection_string = project_client.telemetry.get_connection_string()
+    connection_string = project_client.telemetry.get_application_insights_connection_string()
     ```
 
     > [!TIP]


### PR DESCRIPTION
### Updated telemetry documentation reference

Replaced incorrect usage of a non-existent method `get_connection_string()` with the correct `get_application_insights_connection_string()` when retrieving the Application Insights connection string.

---

#### Context

I initially followed the docs:

```python
project = AIProjectClient(
    credential=DefaultAzureCredential(),
    endpoint=os.getenv("AZURE_AI_FOUNDRY_ENDPOINT"),
)
tracer = trace.get_tracer(__name__)
connection_string = project.telemetry.get_connection_string()
configure_azure_monitor(connection_string=connection_string)
```

This resulted in the following error:
```
Traceback (most recent call last):  line 21, in <module>
    connection_string = project.telemetry.get_connection_string()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TelemetryOperations' object has no attribute 'get_connection_string'. Did you mean: '_connection_string'?
```

#### Investigation
I checked the source code of the SDK and found this in the TelemetryOperations class:

```python
class TelemetryOperations:
    """
    .. warning::
        **DO NOT** instantiate this class directly.

        Instead, you should access the following operations through
        :class:`~azure.ai.projects.AIProjectClient`'s
        :attr:`telemetry` attribute.
    """

    _connection_string: Optional[str] = None

    def __init__(self, outer_instance: "azure.ai.projects.AIProjectClient") -> None:  # type: ignore[name-defined]
        self._outer_instance = outer_instance

    @distributed_trace
    def get_application_insights_connection_string(self) -> str:  # pylint: disable=name-too-long
```

#### Resolution
Switching to the correct method resolved the issue:

```python
project = AIProjectClient(
    credential=DefaultAzureCredential(),
    endpoint=os.getenv("AZURE_AI_FOUNDRY_ENDPOINT"),
)

tracer = trace.get_tracer(__name__)

connection_string = project.telemetry.get_application_insights_connection_string()
configure_azure_monitor(connection_string=connection_string)
```