### PR TITLE
Indicate that only Consumption-type Logic Apps are supported

### DIFF
--- a/articles/ai-foundry/agents/how-to/tools/logic-apps.md
+++ b/articles/ai-foundry/agents/how-to/tools/logic-apps.md
@@ -46,7 +46,8 @@ This article demonstrates how to integrate Logic Apps with Azure AI Agents to ex
     > [!NOTE]
     > For your logic apps to appear in the Azure AI Foundry portal, they must:
     > * Be in the same subscription and resource group.
-    > * Follow a request trigger with a description, and end with a response action. 
+    > * Follow a request trigger with a description, and end with a response action.
+    > * Currently we only support consumption workflows. 
 
     :::image type="content" source="../../media/tools/add-logic-apps.png" alt-text="A screenshot showing the screen to add Logic Apps." lightbox="../../media/tools/add-logic-apps.png":::
 


### PR DESCRIPTION
We have this limitation described in the old "Assistants" section of the documentation: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/assistants-logic-apps#function-calling-on-azure-logic-apps-through-the-assistants-playground. Adding it to the new "Agents Service" section of documentation as well.