### PR TITLE
Fix missing parameter --workspace-name for `az ml online-deployment get-logs`

### DIFF
--- a/articles/machine-learning/how-to-troubleshoot-online-endpoints.md
+++ b/articles/machine-learning/how-to-troubleshoot-online-endpoints.md
@@ -127,13 +127,13 @@ kubectl -n <compute-namespace> logs <container-name>
 To see log output from a container, use the following command:
 
 ```azurecli
-az ml online-deployment get-logs -e <endpoint-name> -n <deployment-name> -l 100
+az ml online-deployment get-logs -w <workspace-name> -e <endpoint-name> -n <deployment-name> -l 100
 ```
 
 Or
 
 ```azurecli
-az ml online-deployment get-logs --endpoint-name <endpoint-name> --name <deployment-name> --lines 100
+az ml online-deployment get-logs --workspace-name <workspace-name> --endpoint-name <endpoint-name> --name <deployment-name> --lines 100
 ```
 
 By default, logs are pulled from the inference server. You can get logs from the storage initializer container by passing `–-container storage-initializer`.


### PR DESCRIPTION
Fix missing parameter --workspace-name for command `az ml online-deployment get-logs`, otherwise it will fail with this error:

> the following arguments are required: --workspace-name/-w

<img width="1649" height="199" alt="image" src="https://github.com/user-attachments/assets/f1f9d198-2f31-48ff-ba39-4d0797141c54" />

Official doc: https://learn.microsoft.com/en-us/cli/azure/ml/online-deployment?view=azure-cli-latest#az-ml-online-deployment-get-logs