### PR TITLE
Update Python quickstart example to use mathematical calculation

### DIFF
--- a/articles/ai-foundry/agents/includes/quickstart-python.md
+++ b/articles/ai-foundry/agents/includes/quickstart-python.md
@@ -21,10 +21,10 @@ ms.date: 11/13/2024
 | Component | Description                                                                                                                                                                                                                               |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Agent     | Custom AI that uses AI models in conjunction with tools.                                                                                                                                                                                  |
-| Tool      | Tools help extend an agent’s ability to reliably and accurately respond during conversation. Such as connecting to user-defined knowledge bases to ground the model, or enabling web search to provide current information.               |
-| Thread    | A conversation session between an agent and a user. Threads store Messages and automatically handle truncation to fit content into a model’s context.                                                                                     |
+| Tool      | Tools help extend an agent's ability to reliably and accurately respond during conversation. Such as connecting to user-defined knowledge bases to ground the model, or enabling web search to provide current information.               |
+| Thread    | A conversation session between an agent and a user. Threads store Messages and automatically handle truncation to fit content into a model's context.                                                                                     |
 | Message   | A message created by an agent or a user. Messages can include text, images, and other files. Messages are stored as a list on the Thread.                                                                                                 |
-| Run       | Activation of an agent to begin running based on the contents of Thread. The agent uses its configuration and Thread’s Messages to perform tasks by calling models and tools. As part of a Run, the agent appends Messages to the Thread. |
+| Run       | Activation of an agent to begin running based on the contents of Thread. The agent uses its configuration and Thread's Messages to perform tasks by calling models and tools. As part of a Run, the agent appends Messages to the Thread. |
 | Run Step  | A detailed list of steps the agent took as part of a Run. An agent can call tools or create Messages during its run. Examining Run Steps allows you to understand how the agent is getting to its results.                                |
 
 Run the following commands to install the python packages.
@@ -88,7 +88,7 @@ with project_client:
     message = project_client.agents.messages.create(
         thread_id=thread.id,
         role="user",  # Role of the message sender
-        content="What is the weather in Seattle today?",  # Message content
+        content="what is 14 + 14",  # Message content
     )
     print(f"Created message, ID: {message['id']}")
     


### PR DESCRIPTION
## Summary

This pull request updates the Python quickstart example in the Azure AI Foundry agent documentation to use a more appropriate example that showcases the code interpreter tool's mathematical capabilities.

## Changes Made

**File updated**: `articles/ai-foundry/agents/includes/quickstart-python.md`

**Change**: Updated the example message from a weather query to a mathematical calculation.

### Before
```python
content="What is the weather in Seattle today?",  # Message content
```

### After
```python
content="what is 14 + 14",  # Message content
```

## Rationale

The current example asks "What is the weather in Seattle today?" which is not well-suited for the code interpreter tool that's included in the quickstart. A weather query would typically require:
- External API calls to weather services
- Web search capabilities
- Location-based services

The updated example "what is 14 + 14" is much more appropriate because:
- It directly showcases the code interpreter tool's computational capabilities
- It provides a simple, clear demonstration of mathematical processing
- It gives users a better understanding of what the agent can compute locally
- The response will be immediate and demonstrative of the agent's basic functionality

## Testing

The updated code maintains all original functionality while providing a more relevant example for the code interpreter tool.

## Type of Change

- [x] Documentation improvement
- [x] Content enhancement
- [ ] Bug fix
- [ ] New feature

This is a minor content improvement that enhances the educational value of the quickstart guide by providing a more appropriate example that aligns with the included tool's capabilities.