### PR TITLE
Update Python quickstart example to use math question "what is 20 + 20"

### DIFF
--- a/articles/ai-foundry/agents/includes/quickstart-python.md
+++ b/articles/ai-foundry/agents/includes/quickstart-python.md
@@ -21,10 +21,10 @@ ms.date: 11/13/2024
 | Component | Description                                                                                                                                                                                                                               |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Agent     | Custom AI that uses AI models in conjunction with tools.                                                                                                                                                                                  |
-| Tool      | Tools help extend an agent’s ability to reliably and accurately respond during conversation. Such as connecting to user-defined knowledge bases to ground the model, or enabling web search to provide current information.               |
-| Thread    | A conversation session between an agent and a user. Threads store Messages and automatically handle truncation to fit content into a model’s context.                                                                                     |
+| Tool      | Tools help extend an agent's ability to reliably and accurately respond during conversation. Such as connecting to user-defined knowledge bases to ground the model, or enabling web search to provide current information.               |
+| Thread    | A conversation session between an agent and a user. Threads store Messages and automatically handle truncation to fit content into a model's context.                                                                                     |
 | Message   | A message created by an agent or a user. Messages can include text, images, and other files. Messages are stored as a list on the Thread.                                                                                                 |
-| Run       | Activation of an agent to begin running based on the contents of Thread. The agent uses its configuration and Thread’s Messages to perform tasks by calling models and tools. As part of a Run, the agent appends Messages to the Thread. |
+| Run       | Activation of an agent to begin running based on the contents of Thread. The agent uses its configuration and Thread's Messages to perform tasks by calling models and tools. As part of a Run, the agent appends Messages to the Thread. |
 | Run Step  | A detailed list of steps the agent took as part of a Run. An agent can call tools or create Messages during its run. Examining Run Steps allows you to understand how the agent is getting to its results.                                |
 
 Run the following commands to install the python packages.
@@ -71,7 +71,7 @@ project_client = AIProjectClient(
 
 code_interpreter = CodeInterpreterTool()
 with project_client:
-    # Create an agent with the Bing Grounding tool
+    # Create an agent with the code interpreter tool
     agent = project_client.agents.create_agent(
         model=os.environ["MODEL_DEPLOYMENT_NAME"],  # Model deployment name
         name="my-agent",  # Name of the agent
@@ -88,7 +88,7 @@ with project_client:
     message = project_client.agents.messages.create(
         thread_id=thread.id,
         role="user",  # Role of the message sender
-        content="What is the weather in Seattle today?",  # Message content
+        content="what is 20 + 20",  # Message content
     )
     print(f"Created message, ID: {message['id']}")
     


### PR DESCRIPTION
This pull request updates the Azure AI Agent Service Python quickstart example to demonstrate a math question instead of a weather question. 

## Changes Made:
- Updated the message content from "What is the weather in Seattle today?" to "what is 20 + 20"
- Updated the comment describing the tool from "Bing Grounding tool" to "code interpreter tool" for accuracy
- Tested the updated code successfully with the provided endpoint and gpt-4o model

## Testing:
The updated code was tested and confirmed to work correctly:
- Agent successfully created
- Math question ("what is 20 + 20") was processed 
- Agent correctly responded with "20 + 20 = 40"
- All operations completed successfully

This change provides a better example for demonstrating basic agent functionality with a simple math calculation that users can easily verify.