### PR TITLE
Fix subscription name formatting for model deployment

### DIFF
--- a/articles/ai-foundry/how-to/deploy-models-serverless.md
+++ b/articles/ai-foundry/how-to/deploy-models-serverless.md
@@ -495,7 +495,8 @@ Furthermore, models offered through Azure Marketplace are available for deployme
     param modelId string = 'azureml://registries/azureml-cohere/models/Cohere-command-r-08-2024'
     
     var modelName = substring(modelId, (lastIndexOf(modelId, '/') + 1))
-    var subscriptionName = '${modelName}-subscription'
+    // Replace period character which is used in some model names (and is not valid in the resource name)
+    var subscriptionName = '${replace(modelName, '.', '')}-subscription'
     
     resource projectName_subscription 'Microsoft.MachineLearningServices/workspaces/marketplaceSubscriptions@2024-04-01-preview' = if (!startsWith(
       modelId,

--- a/articles/ai-foundry/how-to/deploy-models-serverless.md
+++ b/articles/ai-foundry/how-to/deploy-models-serverless.md
@@ -495,8 +495,9 @@ Furthermore, models offered through Azure Marketplace are available for deployme
     param modelId string = 'azureml://registries/azureml-cohere/models/Cohere-command-r-08-2024'
     
     var modelName = substring(modelId, (lastIndexOf(modelId, '/') + 1))
-    // Replace period character which is used in some model names (and is not valid in the resource name)
-    var subscriptionName = '${replace(modelName, '.', '')}-subscription'
+    // Replace period character which is used in some model names (and is not valid in the subscription name)
+    var sanitizedModelName = replace(modelName, '.', '')
+    var subscriptionName = '${sanitizedModelName}-subscription'
     
     resource projectName_subscription 'Microsoft.MachineLearningServices/workspaces/marketplaceSubscriptions@2024-04-01-preview' = if (!startsWith(
       modelId,
@@ -542,7 +543,9 @@ In this section, you create an endpoint for your model. Name the endpoint **myse
     param modelId string = 'azureml://registries/azureml-deepseek/models/DeepSeek-R1'
     
     var modelName = substring(modelId, (lastIndexOf(modelId, '/') + 1))
-    var subscriptionName = '${modelName}-subscription'
+    // Replace period character which is used in some model names (and is not valid in the subscription name)
+    var sanitizedModelName = replace(modelName, '.', '')
+    var subscriptionName = '${sanitizedModelName}-subscription'
     
     resource projectName_endpoint 'Microsoft.MachineLearningServices/workspaces/serverlessEndpoints@2024-04-01-preview' = {
       name: '${projectName}/${endpointName}'


### PR DESCRIPTION
The current Bicep does not work for model names that have periods, such as:

azureml://registries/azureml-cohere/models/Cohere-rerank-v3.5