### PR TITLE
Fix environment variable names for Bing Custom Search

### DIFF
--- a/articles/ai-foundry/agents/how-to/tools/bing-custom-search-samples.md
+++ b/articles/ai-foundry/agents/how-to/tools/bing-custom-search-samples.md
@@ -55,9 +55,9 @@ Use this article to find step-by-step instructions and code samples for using th
 
 * The name of your Grounding with Bing Custom Search configuration, which contains the URLs you want to allow or disallow. You can find it by navigating to the overview page for your resource in the [Azure portal](https://portal.azure.com/). Select **Configurations**, then select your configuration. 
 
-    :::image type="content" source="../../media/tools/bing/custom-connection-name.png" alt-text="A screenshot showing the Grounding with Bing Custom Search connection name. " lightbox="../../media/tools/bing/custom-connection-name.png":::
+    :::image type="content" source="../../media/tools/bing/custom-connection-name.png" alt-text="A screenshot showing the Grounding with Bing Custom Search configuration name. " lightbox="../../media/tools/bing/custom-connection-name.png":::
 
-    Save this connection name to an environment variable named `BING_CUSTOM_CONNECTION_NAME`. 
+    Save this configuration name to an environment variable named `BING_CUSTOM_INSTANCE_NAME`. 
 
 * The names of your model's deployment name. You can find it in **Models + Endpoints** in the left navigation menu. 
 


### PR DESCRIPTION
Submitted by: Tianyang Zheng (alias: t-tzheng)

## Summary

This PR fixes a documentation error in the Bing Custom Search integration guide. The second environment variable was incorrectly labeled as `BING_CUSTOM_CONNECTION_NAME`, which is a duplicate of the first. It should be `BING_CUSTOM_INSTANCE_NAME`, as it refers to the configuration name, not the connection name.

## Changes

- Updated the environment variable name in the second section of the documentation.
- Clarified the distinction between the resource name and the configuration name.

## Reason

The incorrect variable name could lead to confusion or misconfiguration when setting up Bing Custom Search grounding. This fix ensures clarity and correctness.

