### PR TITLE
Add URL specification requirements for sending requests to the private endpoint

### DIFF
--- a/articles/ai-services/cognitive-services-virtual-networks.md
+++ b/articles/ai-services/cognitive-services-virtual-networks.md
@@ -538,7 +538,7 @@ When you create a private endpoint, specify the Azure AI services resource that 
 > Azure OpenAI in Azure AI Foundry Models uses a different private DNS zone and public DNS zone forwarder than other Azure AI services. For the correct zone and forwarder names, see [Azure services DNS zone configuration](/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration).
 
 > [!WARNING]
-> Requests from clients to the private endpoint need to specify the [custom subdomain](https://learn.microsoft.com/en-us/azure/ai-services/cognitive-services-custom-subdomains) of your Azure AI services resource as the endpoint base URL. 
+> Requests from clients to the private endpoint need to specify the [custom subdomain](/azure/ai-services/cognitive-services-custom-subdomains) of your Azure AI services resource as the endpoint base URL. 
 
 Clients on a virtual network that use the private endpoint use the same connection string for the Azure AI services resource as clients connecting to the public endpoint. The exception is the Speech service, which requires a separate endpoint. For more information, see [Use private endpoints with the Speech service](#use-private-endpoints-with-the-speech-service) in this article. DNS resolution automatically routes the connections from the virtual network to the Azure AI services resource over a private link.
 

--- a/articles/ai-services/cognitive-services-virtual-networks.md
+++ b/articles/ai-services/cognitive-services-virtual-networks.md
@@ -537,6 +537,9 @@ When you create a private endpoint, specify the Azure AI services resource that 
 > [!NOTE]
 > Azure OpenAI in Azure AI Foundry Models uses a different private DNS zone and public DNS zone forwarder than other Azure AI services. For the correct zone and forwarder names, see [Azure services DNS zone configuration](/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration).
 
+> [!WARNING]
+> Requests from clients to the private endpoint need to specify the [custom subdomain](https://learn.microsoft.com/en-us/azure/ai-services/cognitive-services-custom-subdomains) of your Azure AI services resource as the endpoint base URL. 
+
 Clients on a virtual network that use the private endpoint use the same connection string for the Azure AI services resource as clients connecting to the public endpoint. The exception is the Speech service, which requires a separate endpoint. For more information, see [Use private endpoints with the Speech service](#use-private-endpoints-with-the-speech-service) in this article. DNS resolution automatically routes the connections from the virtual network to the Azure AI services resource over a private link.
 
 By default, Azure creates a [private DNS zone](/azure/dns/private-dns-overview) attached to the virtual network with the necessary updates for the private endpoints. If you use your own DNS server, you might need to make more changes to your DNS configuration. For updates that might be required for private endpoints, see [Apply DNS changes for private endpoints](#apply-dns-changes-for-private-endpoints) in this article.


### PR DESCRIPTION
A proposal of adding a warning to clarify the requirements for the endpoint URL specified when sending requests to the private endpoint. This requirement has been confirmed internally.

The passage also serves as an extension of the requirement below, written in the same document page, where custom subdomains are expected to be used for scenarios involving firewall rules:
>The request originates from a service that operates within an Azure Virtual Network on the allowed subnet list of the target Azure AI services account. The endpoint request that originated from the virtual network needs to be set as the [custom subdomain](https://learn.microsoft.com/en-us/azure/ai-services/cognitive-services-custom-subdomains) of your Azure AI services account.