### PR TITLE
Fix link to Microsoft Playwright Workspaces

### DIFF
--- a/articles/ai-foundry/agents/how-to/tools/browser-automation.md
+++ b/articles/ai-foundry/agents/how-to/tools/browser-automation.md
@@ -18,7 +18,7 @@ ms.custom: azure-ai-agents
 > The Browser Automation tool comes with significant security risks. Both errors in judgment by the AI and the presence of malicious or confusing instructions on web pages which the AI encounters may cause it to execute commands you or others do not intend, which could compromise the security of your or other users' browsers, computers, and any accounts to which the browser or AI has access, including personal, financial, or enterprise systems. By using the Browser Automation tool, you are acknowledging that you bear responsibility and liability for any use of it and of any resulting agents you create with it, including with respect to any other users to whom you make Browser Automation tool functionality available, including through resulting agents. We strongly recommend using the Browser Automation tool on low-privilege virtual machines with no access to sensitive data or critical resources.
 
 
-The Browser Automation tool enables users to perform real-world browser tasks through natural language prompts. Powered by [Microsoft Playwright Workspaces](/azure/playwright-testing/overview-what-is-microsoft-playwright-testing), it facilitates multi-turn conversations to automate browser-based workflows such as searching, navigating, filling forms, and booking.
+The Browser Automation tool enables users to perform real-world browser tasks through natural language prompts. Powered by [Microsoft Playwright Workspaces](/azure/app-testing/playwright-workspaces/overview-what-is-microsoft-playwright-workspaces), it facilitates multi-turn conversations to automate browser-based workflows such as searching, navigating, filling forms, and booking.
 
 ## How it works
 


### PR DESCRIPTION
Playwright Testing is going EOL. If this service uses the new Playwright Workspaces in Azure App Testing then suggest updating the link accordingly.