### PR TITLE
Update documentation for connecting Open WebUI to Foundry Local

### DIFF
--- a/articles/ai-foundry/foundry-local/how-to/how-to-chat-application-with-open-web-ui.md
+++ b/articles/ai-foundry/foundry-local/how-to/how-to-chat-application-with-open-web-ui.md
@@ -1,7 +1,7 @@
 ---
-title: Integrate Open Web UI with Foundry Local
+title: Integrate Open WebUI with Foundry Local
 titleSuffix: Foundry Local
-description: Learn how to create a chat application using Foundry Local and Open Web UI
+description: Learn how to create a chat application using Foundry Local and Open WebUI
 keywords: Azure AI services, cognitive, AI models, local inference
 ms.service: azure-ai-foundry
 ms.subservice: foundry-local
@@ -15,11 +15,11 @@ ms.custom: build-2025
 #customer intent: As a developer, I want to get started with Foundry Local so that I can run AI models locally.
 ---
 
-# Integrate Open Web UI with Foundry Local
+# Integrate Open WebUI with Foundry Local
 
 [!INCLUDE [foundry-local-preview](./../includes/foundry-local-preview.md)]
 
-This tutorial shows you how to create a chat application using Foundry Local and Open Web UI. When you finish, you have a working chat interface running entirely on your local device.
+This tutorial shows you how to create a chat application using Foundry Local and Open WebUI. When you finish, you have a working chat interface running entirely on your local device.
 
 ## Prerequisites
 
@@ -27,11 +27,11 @@ Before you start this tutorial, you need:
 
 - **Foundry Local** installed on your computer. Read the [Get started with Foundry Local](../get-started.md) guide for installation instructions.
 
-## Set up Open Web UI for chat
+## Set up Open WebUI for chat
 
-1. **Install Open Web UI** by following the instructions from the [Open Web UI GitHub repository](https://github.com/open-webui/open-webui).
+1. **Install Open WebUI** by following the instructions from the [Open WebUI GitHub repository](https://github.com/open-webui/open-webui).
 
-1. **Launch Open Web UI** with this command in your terminal:
+1. **Launch Open WebUI** with this command in your terminal:
 
    ```bash
    open-webui serve
@@ -44,7 +44,7 @@ Before you start this tutorial, you need:
    1. Select **Connections** in the navigation menu.
    1. Enable **Direct Connections** by turning on the toggle. This allows users to connect to their own OpenAI compatible API endpoints.
 
-1. **Connect Open Web UI to Foundry Local**:
+1. **Connect Open WebUI to Foundry Local**:
 
    1. Select **Settings** in the profile menu.
    1. Select **Connections** in the navigation menu.


### PR DESCRIPTION
The connection method for Open WebUI has been updated. Previous instructions no longer work due to recent changes in the integration process. This update reflects the new steps required to successfully connect Open WebUI to Foundry Local.

<img width="935" height="646" alt="image" src="https://github.com/user-attachments/assets/610345ee-ccb1-47ff-9583-901176f61529" />

<img width="935" height="646" alt="image" src="https://github.com/user-attachments/assets/9985d641-47ee-4027-87be-133df15aa5f9" />
