### PR TITLE
Change model reasoning effort from high to medium

### DIFF
--- a/articles/ai-foundry/openai/how-to/codex.md
+++ b/articles/ai-foundry/openai/how-to/codex.md
@@ -69,7 +69,7 @@ codex --version # verify installation
     ```text
     model = "gpt-5-codex"  # Replace with your actual Azure model deployment name
     model_provider = "azure"
-    model_reasoning_effort = "high"
+    model_reasoning_effort = "medium"
     
     [model_providers.azure]
     name = "Azure OpenAI"


### PR DESCRIPTION
According to the OpenAI documentation, using medium is the recommended setting. I experimented with high, and it turned out to be significantly more expensive. More details here: https://github.com/openai/codex/blob/main/docs/config.md#model_reasoning_effort