### PR TITLE
Rename AudioFormat to InputAudioFormat and OutputAudioFormat

### DIFF
--- a/articles/ai-services/speech-service/includes/quickstarts/voice-live-api/python.md
+++ b/articles/ai-services/speech-service/includes/quickstarts/voice-live-api/python.md
@@ -146,7 +146,8 @@ The sample code in this quickstart uses either Microsoft Entra ID or an API key 
         ServerVad,
         AzureStandardVoice,
         Modality,
-        AudioFormat,
+        InputAudioFormat,
+        OutputAudioFormat
     )
     
     # Set up logging


### PR DESCRIPTION
azure.ai.voicelive.models.AudioFormat enum chaged to (was separated to) azure.ai.voicelive.models.InputAudioFormat and azure.ai.voicelive.models.OutputAudioFormat