### PR TITLE
Update Bing Grounding documentation with usage notes

### DIFF
--- a/articles/foundry-classic/agents/how-to/tools-classic/bing-grounding.md
+++ b/articles/foundry-classic/agents/how-to/tools-classic/bing-grounding.md
@@ -29,6 +29,7 @@ Developers and end users don't have access to raw content returned from Groundin
 
 >[!IMPORTANT]
 > 1. Your usage of Grounding with Bing Search can incur costs. See the [pricing page](https://www.microsoft.com/en-us/bing/apis/grounding-pricing) for details.
+> 2. Only Paid and Pay-as-you-go Azure subscriptions are eligible for Grounding with Bing Search. Sponsored or subscriptions based on free credit are not eligible to deploy Grounding with Bing Search. 
 > 1. By creating and using a Grounding with Bing Search resource through code-first experience, such as Azure CLI, or deploying through deployment template, you agree to be bound by and comply with the terms available at https://www.microsoft.com/en-us/bing/apis/grounding-legal, which might be updated from time to time.
 > 1. When you use Grounding with Bing Search, your customer data is transferred outside of the Azure compliance boundary to the Grounding with Bing Search service. Grounding with Bing Search is not subject to the same data processing terms (including location of processing) and does not have the same compliance standards and certifications as the Foundry Agent Service, as described in the [Grounding with Bing Search Terms of Use](https://www.microsoft.com/en-us/bing/apis/grounding-legal). It is your responsibility to assess whether use of Grounding with Bing Search in your agent meets your needs and requirements.
 

--- a/articles/foundry-classic/agents/how-to/tools-classic/bing-grounding.md
+++ b/articles/foundry-classic/agents/how-to/tools-classic/bing-grounding.md
@@ -29,7 +29,7 @@ Developers and end users don't have access to raw content returned from Groundin
 
 >[!IMPORTANT]
 > 1. Your usage of Grounding with Bing Search can incur costs. See the [pricing page](https://www.microsoft.com/en-us/bing/apis/grounding-pricing) for details.
-> 2. Only Paid and Pay-as-you-go Azure subscriptions are eligible for Grounding with Bing Search. Sponsored or subscriptions based on free credit are not eligible to deploy Grounding with Bing Search. 
+> 1. Only paid and pay-as-you-go Azure subscriptions are eligible for Grounding with Bing Search. Sponsored subscriptions or subscriptions based on free credits are not eligible to deploy Grounding with Bing Search.
 > 1. By creating and using a Grounding with Bing Search resource through code-first experience, such as Azure CLI, or deploying through deployment template, you agree to be bound by and comply with the terms available at https://www.microsoft.com/en-us/bing/apis/grounding-legal, which might be updated from time to time.
 > 1. When you use Grounding with Bing Search, your customer data is transferred outside of the Azure compliance boundary to the Grounding with Bing Search service. Grounding with Bing Search is not subject to the same data processing terms (including location of processing) and does not have the same compliance standards and certifications as the Foundry Agent Service, as described in the [Grounding with Bing Search Terms of Use](https://www.microsoft.com/en-us/bing/apis/grounding-legal). It is your responsibility to assess whether use of Grounding with Bing Search in your agent meets your needs and requirements.
 


### PR DESCRIPTION
Added important usage notes and compliance information for Grounding with Bing Search.

"Only Paid and Pay-as-you-go Azure subscriptions are eligible for Grounding with Bing Search. Sponsored or subscriptions based on free credit are not eligible to deploy Grounding with Bing Search. "