### PR TITLE
Update latency recommendations for GPT models to remove stale ref to GPT4oMini

### DIFF
--- a/articles/foundry-classic/openai/how-to/latency.md
+++ b/articles/foundry-classic/openai/how-to/latency.md
@@ -88,7 +88,7 @@ There are several factors that you can control to improve per-call latency of yo
 
 ### Model selection
 
-Latency varies based on what model you're using. For an identical request, expect that different models have different latencies for the chat completions call. If your use case requires the lowest latency models with the fastest response times, we recommend the latest [GPT-4o mini model](../../foundry-models/concepts/models-sold-directly-by-azure.md).
+Latency varies based on what model you're using. For an identical request, expect that different models have different latencies for the chat completions call. If your use case requires the lowest latency models with the fastest response times, we recommend the mini or nano variations of the latest [GPT models](../../foundry-models/concepts/models-sold-directly-by-azure.md).
 
 ### Generation size and Max tokens
 
@@ -162,7 +162,7 @@ Time from the first token to the last token, divided by the number of generated 
 
 ## Summary
 
-* **Model latency**: If model latency is important to you, we recommend trying out the [GPT-4o mini model](../../foundry-models/concepts/models-sold-directly-by-azure.md).
+* **Model latency**: If model latency is important to you, we recommend trying out the mini or nano variations of the latest [GPT models](../../foundry-models/concepts/models-sold-directly-by-azure.md).
 
 * **Lower max tokens**: OpenAI has found that even in cases where the total number of tokens generated is similar the request with the higher value set for the max token parameter will have more latency.
 


### PR DESCRIPTION
Update latency recommendations for GPT models to remove ref to GPT4oMini
Simple change : 
Replaced stale recommendation for "GPT4o-mini" in 2 places to a more generic and stable in time "mini or nano variation of latest GPT model".

link remains unchanged (was already pointing to general Direct Models page)