### PR TITLE
Clarify identity type support for BYOS

### DIFF
--- a/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
+++ b/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
@@ -208,7 +208,7 @@ To check BYOS configuration of a Foundry resource for Speech with Azure portal, 
 1.  Select *Storage* menu in the *Resource Management* group.
 1.  Check that:
     1. *Attached storage* field contains the Azure resource ID of the BYOS-associated Storage account.
-    1. *Identity type* has *System Assigned* selected.
+    1. *Identity type* has *System Assigned* selected. Note: *User Assigned* identity is not supported for BYOS..
 
 If *Storage* menu item is missing in the *Resource Management* group, the selected Speech resource isn't BYOS-enabled.
 
@@ -326,7 +326,7 @@ If you perform all actions in the section, your Storage account is in the follow
 - External network traffic is allowed.
 - Access to Storage account using Storage account key is prohibited.
 - Access to Storage account blob storage using [shared access signatures (SAS)](/azure/storage/common/storage-sas-overview) is prohibited. (Except for [User delegation SAS](/azure/storage/common/shared-key-authorization-prevent#understand-how-disallowing-shared-key-affects-sas-tokens))
-- Access to the BYOS-enabled Speech resource is allowed using the resource [system assigned managed identity](/azure/active-directory/managed-identities-azure-resources/overview) and [User delegation SAS](/azure/storage/common/storage-sas-overview#user-delegation-sas).
+- Access to the BYOS-enabled Speech resource is allowed using the resource [system assigned managed identity](/azure/active-directory/managed-identities-azure-resources/overview) and [User delegation SAS](/azure/storage/common/storage-sas-overview#user-delegation-sas). Note: *User Assigned* identity is not supported for BYOS. Also, if you want to change the identity from user assigned to system assigned, you need to redeploy the Speech service as well. 
 
 These are the most restricted security settings possible for the text to speech scenario. You can further customize them according to your needs.
 

--- a/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
+++ b/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
@@ -208,7 +208,7 @@ To check BYOS configuration of a Foundry resource for Speech with Azure portal, 
 1.  Select *Storage* menu in the *Resource Management* group.
 1.  Check that:
     1. *Attached storage* field contains the Azure resource ID of the BYOS-associated Storage account.
-    1. *Identity type* has *System Assigned* selected. Note: *User Assigned* identity is not supported for BYOS..
+    1. *Identity type* has *System Assigned* selected. Note: *User Assigned* identity is not supported for BYOS.
 
 If *Storage* menu item is missing in the *Resource Management* group, the selected Speech resource isn't BYOS-enabled.
 

--- a/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
+++ b/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
@@ -326,7 +326,7 @@ If you perform all actions in the section, your Storage account is in the follow
 - External network traffic is allowed.
 - Access to Storage account using Storage account key is prohibited.
 - Access to Storage account blob storage using [shared access signatures (SAS)](/azure/storage/common/storage-sas-overview) is prohibited. (Except for [User delegation SAS](/azure/storage/common/shared-key-authorization-prevent#understand-how-disallowing-shared-key-affects-sas-tokens))
-- Access to the BYOS-enabled Speech resource is allowed using the resource [system assigned managed identity](/azure/active-directory/managed-identities-azure-resources/overview) and [User delegation SAS](/azure/storage/common/storage-sas-overview#user-delegation-sas). Note: *User Assigned* identity is not supported for BYOS. Also, if you want to change the identity from user assigned to system assigned, you need to redeploy the Speech service as well. 
+- Access to the BYOS-enabled Speech resource is allowed using the resource [system assigned managed identity](/azure/active-directory/managed-identities-azure-resources/overview) and [User delegation SAS](/azure/storage/common/storage-sas-overview#user-delegation-sas). Note: *User Assigned* identity is not supported for BYOS. Also, if you want to change the identity from *User Assigned* to *System Assigned*, you need to redeploy the Speech service. 
 
 These are the most restricted security settings possible for the text to speech scenario. You can further customize them according to your needs.
 

--- a/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
+++ b/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
@@ -390,4 +390,4 @@ You need to allow access for the machine, where you run the browser using Speech
 
 - [Use the Bring your own storage (BYOS) Speech resource for Speech to text](bring-your-own-storage-speech-resource-speech-to-text.md)
 - Foundry [Connect to your own storage](../../ai-foundry/how-to/bring-your-own-azure-storage-foundry.md)
-- Foundry [Connect your own storage for Speech and Language services](../../ai-foundry/how-to/bring-your-own-azure-storage-speech-language-services.md)**
+- Foundry [Connect your own storage for Speech and Language services](../../ai-foundry/how-to/bring-your-own-azure-storage-speech-language-services.md)

--- a/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
+++ b/articles/ai-services/speech-service/bring-your-own-storage-speech-resource.md
@@ -208,7 +208,10 @@ To check BYOS configuration of a Foundry resource for Speech with Azure portal, 
 1.  Select *Storage* menu in the *Resource Management* group.
 1.  Check that:
     1. *Attached storage* field contains the Azure resource ID of the BYOS-associated Storage account.
-    1. *Identity type* has *System Assigned* selected. Note: *User Assigned* identity is not supported for BYOS.
+    1. *Identity type* has *System Assigned* selected. 
+    
+    > [!NOTE]
+    > *User Assigned* identity is not supported for BYOS.
 
 If *Storage* menu item is missing in the *Resource Management* group, the selected Speech resource isn't BYOS-enabled.
 
@@ -326,7 +329,10 @@ If you perform all actions in the section, your Storage account is in the follow
 - External network traffic is allowed.
 - Access to Storage account using Storage account key is prohibited.
 - Access to Storage account blob storage using [shared access signatures (SAS)](/azure/storage/common/storage-sas-overview) is prohibited. (Except for [User delegation SAS](/azure/storage/common/shared-key-authorization-prevent#understand-how-disallowing-shared-key-affects-sas-tokens))
-- Access to the BYOS-enabled Speech resource is allowed using the resource [system assigned managed identity](/azure/active-directory/managed-identities-azure-resources/overview) and [User delegation SAS](/azure/storage/common/storage-sas-overview#user-delegation-sas). Note: *User Assigned* identity is not supported for BYOS. Also, if you want to change the identity from *User Assigned* to *System Assigned*, you need to redeploy the Speech service. 
+- Access to the BYOS-enabled Speech resource is allowed using the resource [system assigned managed identity](/azure/active-directory/managed-identities-azure-resources/overview) and [User delegation SAS](/azure/storage/common/storage-sas-overview#user-delegation-sas). 
+
+> [!NOTE]
+> *User Assigned* identity is not supported for BYOS. Also, if you want to change the identity from *User Assigned* to *System Assigned*, you need to redeploy the Speech service. 
 
 These are the most restricted security settings possible for the text to speech scenario. You can further customize them according to your needs.
 


### PR DESCRIPTION
Added note about User Assigned identity not being supported for BYOS and redeployment requirement for changing identity types. We worked with customer over 5 days to identify this issue as they were not convinced to use system assigned identity, saying that its not mentioned in the docs. Also, changing the identity type after creating speech service doesnt work. Support and BYOS PG were also not able to point this out. Adding these comments, hoping it would save time for others.