### PR TITLE
fix: replace 'Azure Active Directory' with 'Microsoft Entra ID' in Document Intelligence Studio quickstart

### DIFF
--- a/articles/ai-services/document-intelligence/quickstarts/get-started-studio.md
+++ b/articles/ai-services/document-intelligence/quickstarts/get-started-studio.md
@@ -26,7 +26,7 @@ monikerRange: '>=doc-intel-3.0.0'
 > [!TIP]
 > Create a Microsoft Foundry resource if you plan to access multiple Foundry Tools under a single endpoint/key. For Document Intelligence access only, create a Document Intelligence resource. You need a single-service resource if you intend to use [Microsoft Entra authentication](/azure/active-directory/authentication/overview-authentication).
 >
-> Document Intelligence now supports Azure Active Directory token authentication in addition to local (key-based) authentication when you access Document Intelligence resources and storage accounts. Follow the instructions to set up correct access roles, especially if your resources are applied with the `DisableLocalAuth` policy.
+> Document Intelligence now supports Microsoft Entra ID token authentication in addition to local (key-based) authentication when you access Document Intelligence resources and storage accounts. Follow the instructions to set up correct access roles, especially if your resources are applied with the `DisableLocalAuth` policy.
 
 There are added prerequisites for using custom models in Document Intelligence Studio. For step-by-step guidance, see [Document Intelligence Studio custom projects](studio-custom-project.md).
 
@@ -42,7 +42,7 @@ For more information, see the following guidance:
   * [Disable local authentication for Foundry Tools](../../disable-local-auth.md)
   * [Prevent Shared Key authorization for an Azure Storage account](/azure/storage/common/shared-key-authorization-prevent)
 
-If local (key-based) authentication is disabled for your Document Intelligence service resource, be sure to obtain the Cognitive Services User role and your Azure Active Directory token to authenticate requests in Document Intelligence Studio. The Contributor role allows you to list only keys but doesn't give you permission to use the resource when key access is disabled.
+If local (key-based) authentication is disabled for your Document Intelligence service resource, be sure to obtain the Cognitive Services User role and your Microsoft Entra ID token to authenticate requests in Document Intelligence Studio. The Contributor role allows you to list only keys but doesn't give you permission to use the resource when key access is disabled.
 
 #### Designate role assignments
 


### PR DESCRIPTION
## What does this PR change?

Replaces two instances of the outdated "Azure Active Directory" with the correct post-rename name "Microsoft Entra ID" in the Document Intelligence Studio quickstart.

**Change 1:**
Before: > Document Intelligence now supports Azure Active Directory token authentication
After:  > Document Intelligence now supports Microsoft Entra ID token authentication

**Change 2:**
Before: > be sure to obtain the Cognitive Services User role and your Azure Active Directory token
After:  > be sure to obtain the Cognitive Services User role and your Microsoft Entra ID token

## Why?
Azure Active Directory was renamed to Microsoft Entra ID in July 2023. The rest of the article already uses "Microsoft Entra ID" correctly. These were the two remaining stale references.

## References
https://learn.microsoft.com/en-us/entra/fundamentals/new-name