### PR TITLE
Fix on-prem access doc banners and add to Foundry TOC

### DIFF
--- a/articles/foundry-classic/how-to/access-on-premises-resources.md
+++ b/articles/foundry-classic/how-to/access-on-premises-resources.md
@@ -1,10 +1,10 @@
 ---
-title: "How to access on-premises resources (classic)"
-description: "Learn how to configure a Microsoft Foundry managed network to securely allow access to your on-premises resources. (classic)"
+title: "How to access on-premises resources"
+description: "Learn how to configure a Microsoft Foundry managed network to securely allow access to your on-premises resources."
 manager: mcleans
 ms.service: microsoft-foundry
 ms.custom:
-  - hub-only
+  - classic-and-new
   - dev-focus
 ms.topic: how-to
 ms.date: 01/06/2026
@@ -15,11 +15,10 @@ ai-usage: ai-assisted
 # Customer intent: As an admin, I want to allow my developers to securely access on-premises resources from Microsoft Foundry.
 ---
 
-# Access on-premises resources from your Microsoft Foundry managed network (classic)
+# Access on-premises resources from your Microsoft Foundry managed network
 
-[!INCLUDE [classic-banner](../includes/classic-banner.md)]
-
-[!INCLUDE [hub-only](../includes/uses-hub-only.md)]
+> [!NOTE]
+> This networking feature works for both new Foundry projects and classic (hub-based) projects. The procedural examples and CLI/SDK commands in this article currently use the classic hub-based workflow. The same Application Gateway approach applies when your Foundry project uses a managed virtual network, regardless of project type.
 
 You can configure an Azure Application Gateway to let your managed virtual network in [Microsoft Foundry](https://ai.azure.com/?cid=learnDocs) reach non-Azure resources in another virtual network or on-premises. The gateway provides a secure, private end-to-end path to those resources.
 

--- a/articles/foundry/how-to/configure-private-link.md
+++ b/articles/foundry/how-to/configure-private-link.md
@@ -190,6 +190,8 @@ To access your Foundry resource that has public network access disabled and is b
 * [ExpressRoute](/azure/expressroute/) - Connect on-premises networks to Azure over a private connection through a connectivity provider.
 * [Azure Bastion VM](/azure/bastion/bastion-overview) - Create an Azure virtual machine (a jump box) in the virtual network, then connect to it through Azure Bastion using RDP or SSH from your browser. Use the VM as your development environment. Because it's in the virtual network, it can access the resource directly.
 
+To access non-Azure resources in another virtual network or on-premises from your managed virtual network, see [Access on-premises resources](/azure/foundry-classic/how-to/access-on-premises-resources).
+
 
 ## Set up walkthrough for outbound network isolation
 

--- a/articles/foundry/toc-files-foundry/security-governance/toc.yml
+++ b/articles/foundry/toc-files-foundry/security-governance/toc.yml
@@ -20,6 +20,8 @@ items:
     href: ../../how-to/configure-private-link.md
   - name: Managed virtual network
     href: ../../how-to/managed-virtual-network.md
+  - name: Access on-premises resources
+    href: ../../../foundry-classic/how-to/access-on-premises-resources.md?context=/azure/foundry/context/context
   - name: Network security perimeter
     href: ../../how-to/add-foundry-to-network-security-perimeter.md    
 


### PR DESCRIPTION
## Summary

Changes requested by **Meera Kurup** to fix confusing documentation for enterprise networking customers.

### Changes

1. **access-on-premises-resources.md**: Removed misleading classic-only banners that confused customers. The on-prem access feature (via Application Gateway) works for both classic and new Foundry projects. Replaced with a clear note explaining the feature is portal-agnostic while current examples use the classic hub-based workflow.

2. **security-governance/toc.yml**: Added 'Access on-premises resources' to the new Foundry TOC under Network security, so customers using the new portal can discover this article.

3. **configure-private-link.md**: Added inline cross-reference to the on-prem access article for in-flow discoverability.

### Still needed (not in this PR)
- Updated diagram PNGs for configure-private-link.md (source images shared by Meera on SharePoint, not yet added to repo)

### Related context
- Meera's request via Teams (Mar 19): \can you get this doc to show up in our new TOC?\ and \	he note at the top of the doc is confusing customers\
