### PR TITLE
Fix typo in model ID from 'gpt-5.4.nano' to 'gpt-5.4-nano'

### DIFF
--- a/articles/foundry/openai/includes/models-azure-direct-openai.md
+++ b/articles/foundry/openai/includes/models-azure-direct-openai.md
@@ -54,7 +54,7 @@ Azure OpenAI is powered by a diverse set of models with different capabilities a
 | `gpt-5.4` | See the [models table](#model-summary-table-and-region-availability) |
 | `gpt-5.4-pro` |  See the [models table](#model-summary-table-and-region-availability)  |
 | `gpt-5.4-mini` | See the [models table](#model-summary-table-and-region-availability)|
-| `gpt-5.4.nano` | See the [models table](#model-summary-table-and-region-availability) |
+| `gpt-5.4-nano` | See the [models table](#model-summary-table-and-region-availability) |
 
 
 |  Model ID  | Description | Context Window | Max Output Tokens | Training Data (up to)  |


### PR DESCRIPTION
## Description

The model name `gpt-5.4-nano` is incorrectly written as `gpt-5.4.nano`
(period instead of hyphen) in `articles/foundry/openai/includes/models-azure-direct-openai.md`.

Because this file is included via transclusion in multiple Learn articles,
the same typo currently surfaces on at least two public pages:

- [Foundry Models sold directly by Azure — GPT-5.4 section](https://learn.microsoft.com/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure#gpt-54)
- [Azure OpenAI reasoning models — Region availability](https://learn.microsoft.com/azure/foundry/openai/how-to/reasoning#availability)

## Evidence this is a typo, not the actual model name

Within the same include file, the model is consistently referred to as
`gpt-5.4-nano` (hyphen) in:

- The capabilities table immediately below the affected region table
  (Model ID column: `gpt-5.4-nano` (2026-03-17))
- The Global Standard / Data Zone Standard model availability summary tables
  (column header: `gpt-5.4-nano`)

The Azure OpenAI quotas-and-limits article and reasoning model API & feature
support tables also use the hyphenated form throughout.

## Impact

Users copy-pasting the model name from these availability tables into their
deployment configuration (`az cognitiveservices account deployment create
--model-name "gpt-5.4.nano"`) will receive a "model not found" error.

## Changes

- Replaced `gpt-5.4.nano` with `gpt-5.4-nano` in all occurrences within
  `articles/foundry/openai/includes/models-azure-direct-openai.md`.
- No other changes.
