### PR TITLE
Document Public Preview supported regions for post-stream refinement

### DIFF
--- a/articles/ai-services/speech-service/includes/how-to/post-processing/intro.md
+++ b/articles/ai-services/speech-service/includes/how-to/post-processing/intro.md
@@ -13,4 +13,4 @@ The following values are supported:
 | Value | Description |
 |-------|-------------|
 | `TrueText` | Applies display formatting to recognition results, including punctuation and capitalization, to produce more readable output. |
-| `PostRefinement` | Improves final transcript accuracy by running a second recognition pass in parallel with real-time streaming. Intermediate results remain low-latency; only the final result for each segment is replaced with a more accurate version. This option is currently in public preview. |
+| `PostRefinement` | Improves final transcript accuracy by running a second recognition pass in parallel with real-time streaming. Intermediate results remain low-latency; only the final result for each segment is replaced with a more accurate version. This option is currently in public preview and is only available in [selected Azure regions](../../recognize-speech/post-stream-refinement.md#supported-regions). |

--- a/articles/ai-services/speech-service/includes/how-to/recognize-speech/post-stream-refinement.md
+++ b/articles/ai-services/speech-service/includes/how-to/recognize-speech/post-stream-refinement.md
@@ -53,6 +53,20 @@ Some important considerations for post-stream refinement:
 - Post-stream refinement and semantic segmentation can't be used together.
 - Post-stream refinement and TrueText are separate values of the same `SpeechServiceResponse_PostProcessingOption` property. Only one value can be set at a time.
 
+### Supported regions
+
+During public preview, post-stream refinement is available only in the following Azure regions. Requests sent to other regions return an error such as `PostRefinement is not supported in region '<region>'`. Make sure your Speech resource is created in one of these regions before you set `SpeechServiceResponse_PostProcessingOption` to `PostRefinement`.
+
+| Region | Region identifier |
+|---|---|
+| East US | `eastus` |
+| West US | `westus` |
+| North Europe | `northeurope` |
+| Central India | `centralindia` |
+| Southeast Asia | `southeastasia` |
+
+Additional regions, including West Europe, will be added as the feature progresses toward general availability. For the latest status, see [What's new in Speech](../../../releasenotes.md).
+
 For more information about post-processing options, see [How to use post-processing](../../../how-to-post-processing.md).
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary
Adds an explicit **Supported regions** section to the post-stream refinement how-to include, and links to it from the post-processing options table on the parent page.

## Why
Customer feedback after the Public Preview launch:

> *"It would be great to try this out but I can't find any information on which regions it's available in. I've tried a couple of different regions and got an error e.g. `PostRefinement is not supported in region 'ProductionWEU'`."*

The published docs don't currently list the preview footprint, so customers in unsupported regions (e.g. West Europe) hit the service-side error with no path to self-serve.

## Changes
- `articles/ai-services/speech-service/includes/how-to/recognize-speech/post-stream-refinement.md` — new `### Supported regions` section listing the 5 Azure regions where the Public Preview is enabled (East US, West US, North Europe, Central India, Southeast Asia) and quoting the exact error string so search lands customers here.
- `articles/ai-services/speech-service/includes/how-to/post-processing/intro.md` — extended the `PostRefinement` row in the post-processing options table with a link to the new `#supported-regions` anchor.

Following the same convention as `regions.md`, sovereign clouds aren't listed on this global Learn page.

## Validation
- Region list cross-checked against the Public Preview launch email and the Realtime Multi-Recognizer shiproom deck.
- Anchor link `../../recognize-speech/post-stream-refinement.md#supported-regions` resolves from the `post-processing` include path.

/cc @PatrickFarley for review.