### PR TITLE
Update allowed domains for network management

### DIFF
--- a/articles/machine-learning/how-to-managed-network.md
+++ b/articles/machine-learning/how-to-managed-network.md
@@ -1132,6 +1132,10 @@ If you plan to use __HuggingFace models__ with Azure Machine Learning, add outbo
 * `production.cloudflare.docker.com`
 * `cdn.auth0.com`
 * `cdn-lfs.huggingface.co`
+* `xethub.hf.co`
+* `*.xethub.hf.co`
+* `huggingface.co`
+* `*.huggingface.co`
 
 ### Scenario: Enable access from selected IP Addresses
 


### PR DESCRIPTION
Added additional domains for Hugging Face access because in most restricted deployment it will face with error pointing that these fqdns are blocked. 

- HuggingFace	huggingface.co, *.huggingface.co	Model config + tokenizer downloads 

- HuggingFace Xet	xethub.hf.co, *.xethub.hf.co	Model weights (safetensors, ONNX) via Xet storage