### PR TITLE
Change Claude Code environment variables format for vscode extension

### DIFF
--- a/articles/foundry/foundry-models/how-to/configure-claude-code.md
+++ b/articles/foundry/foundry-models/how-to/configure-claude-code.md
@@ -267,13 +267,11 @@ The Claude Code VS Code extension provides a native graphical interface for Clau
 1. Select **Edit in settings.json** and add the following configuration:
 
     ```json
-    {
-      "Claude Code: Environment Variables": {
-        "CLAUDE_CODE_USE_FOUNDRY": "1",
-        "ANTHROPIC_FOUNDRY_RESOURCE": "<your-resource-name>",
-        "ANTHROPIC_FOUNDRY_API_KEY": "<optional-for-non-entra-auth>"
-      }
-    }
+      "Claude Code: Environment Variables": [
+        {"name": "CLAUDE_CODE_USE_FOUNDRY", "value": "1"},
+        {"name": "ANTHROPIC_FOUNDRY_RESOURCE", "value": "<your-resource-name>"},
+        {"name": "ANTHROPIC_FOUNDRY_API_KEY", "value": "<optional-for-non-entra-auth>"
+      ]
     ```
 
 1. Select the **Spark icon** in the sidebar to open the Claude Code panel.

--- a/articles/foundry/foundry-models/how-to/configure-claude-code.md
+++ b/articles/foundry/foundry-models/how-to/configure-claude-code.md
@@ -267,11 +267,13 @@ The Claude Code VS Code extension provides a native graphical interface for Clau
 1. Select **Edit in settings.json** and add the following configuration:
 
     ```json
-      "Claude Code: Environment Variables": [
-        {"name": "CLAUDE_CODE_USE_FOUNDRY", "value": "1"},
-        {"name": "ANTHROPIC_FOUNDRY_RESOURCE", "value": "<your-resource-name>"},
-        {"name": "ANTHROPIC_FOUNDRY_API_KEY", "value": "<optional-for-non-entra-auth>"
-      ]
+      {
+        "Claude Code: Environment Variables": [
+          { "name": "CLAUDE_CODE_USE_FOUNDRY", "value": "1" },
+          { "name": "ANTHROPIC_FOUNDRY_RESOURCE", "value": "<your-resource-name>" },
+          { "name": "ANTHROPIC_FOUNDRY_API_KEY", "value": "<optional-for-non-entra-auth>" }
+        ]
+      }
     ```
 
 1. Select the **Spark icon** in the sidebar to open the Claude Code panel.


### PR DESCRIPTION
Updated the configuration format for Claude Code environment variables from an object to an array for vscode extension. The actual format doesn't work