### PR TITLE
Add documentation for blocklists as guardrail controls

### DIFF
--- a/articles/foundry/guardrails/how-to-create-guardrails.md
+++ b/articles/foundry/guardrails/how-to-create-guardrails.md
@@ -78,7 +78,7 @@ You can use a blocklist as an additional filtering mechanism in your guardrail. 
 
 To add a blocklist control to your guardrail:
 
-1. In the control list, select 'Blocklists'
+1. In the control list, select **Blocklists**.
 2. From the dropdown menu, select the blocklist that you want to use. You can select either a custom blocklist or a built-in blocklist.
 3. If you have not created a blocklist yet, select the option to create one from the dropdown menu.
 4. Save your changes to apply the blocklist to the guardrail.

--- a/articles/foundry/guardrails/how-to-create-guardrails.md
+++ b/articles/foundry/guardrails/how-to-create-guardrails.md
@@ -81,7 +81,7 @@ To add a blocklist control to your guardrail:
 1. In the control list, select **Blocklists**.
 2. From the dropdown menu, select the blocklist that you want to use. You can select either a custom blocklist or a built-in blocklist.
 3. If you have not created a blocklist yet, select the option to create one from the dropdown menu.
-4. Save your changes to apply the blocklist to the guardrail.
+4. Select **Save** to apply the blocklist to the guardrail.
 
 ## Assign a guardrail to agents and models
 

--- a/articles/foundry/guardrails/how-to-create-guardrails.md
+++ b/articles/foundry/guardrails/how-to-create-guardrails.md
@@ -72,6 +72,17 @@ To edit a control by overriding it:
 3. Select **Add control**.
 4. A pop-up asks for confirmation to override the existing control. Select **Confirm**.
 
+## Add a blocklist as control in a guardrail 
+
+You can use a blocklist as an additional filtering mechanism in your guardrail. For more information about blocklists, see [more about blocklist](../openai/how-to/use-blocklists.md).
+
+To add a blocklist control to your guardrail:
+
+1. In the control list, select 'Blocklists'
+2. From the dropdown menu, select the blocklist that you want to use. You can select either a custom blocklist or a built-in blocklist.
+3. If you have not created a blocklist yet, select the option to create one from the dropdown menu.
+4. Save your changes to apply the blocklist to the guardrail.
+
 ## Assign a guardrail to agents and models
 
 After adding, editing, and/or deleting controls as desired:

--- a/articles/foundry/guardrails/how-to-create-guardrails.md
+++ b/articles/foundry/guardrails/how-to-create-guardrails.md
@@ -72,9 +72,9 @@ To edit a control by overriding it:
 3. Select **Add control**.
 4. A pop-up asks for confirmation to override the existing control. Select **Confirm**.
 
-## Add a blocklist as control in a guardrail 
+## Add a blocklist as control in a guardrail
 
-You can use a blocklist as an additional filtering mechanism in your guardrail. For more information about blocklists, see [more about blocklist](../openai/how-to/use-blocklists.md).
+You can use a blocklist as an additional filtering mechanism in your guardrail. For more information about blocklists, see [Learn more about blocklists](../openai/how-to/use-blocklists.md).
 
 To add a blocklist control to your guardrail:
 


### PR DESCRIPTION
**Summary**
Adds documentation for configuring blocklists as controls in Microsoft Foundry guardrails.

**Changes**
- Added a new Add a blocklist as a control section to the guardrails documentation. 
- Added step-by-step instructions for -selecting a custom or built-in blocklist from the Controls list. 
- Added guidance for creating a blocklist if one does not already exist. 
- Added a cross-reference to the blocklists documentation.

**Why**
Blocklists can be used as an additional filtering mechanism in guardrails. This update makes the capability discoverable from the guardrails documentation and provides users with the steps required to configure it.