### PR TITLE
Add requirement for ACRs enabling azureADAuthenticationAsArmPolicy for Foundry Hosted Agent image access

### DIFF
--- a/articles/foundry/agents/concepts/hosted-agent-permissions.md
+++ b/articles/foundry/agents/concepts/hosted-agent-permissions.md
@@ -192,7 +192,7 @@ Creating an Azure Container Registry requires the `Microsoft.ContainerRegistry/r
 > [!NOTE]
 > For Hosted agents, the container registry must currently be reachable over its public endpoint. Placing ACR behind a private network (private endpoint with public network access disabled) isn't currently supported. For the full list of network constraints, see [Limitations](../how-to/virtual-networks.md#limitations).
 
-The registry's `azureADAuthenticationAsArmPolicy` policy status must be set to `enabled`. To check or update the status, use [`az acr config authentication-as-arm`](/cli/azure/acr/config/authentication-as-arm).
+The registry's `azureADAuthenticationAsArmPolicy` policy status must be set to `enabled`. This setting allows ACR to accept Microsoft Entra tokens scoped to Azure Resource Manager. To check or update the status, use [`az acr config authentication-as-arm`](/cli/azure/acr/config/authentication-as-arm).
 
 | Built-in role | Scope | Can assignee create a container registry? |
 | --- | --- | --- |

--- a/articles/foundry/agents/concepts/hosted-agent-permissions.md
+++ b/articles/foundry/agents/concepts/hosted-agent-permissions.md
@@ -192,7 +192,7 @@ Creating an Azure Container Registry requires the `Microsoft.ContainerRegistry/r
 > [!NOTE]
 > For Hosted agents, the container registry must currently be reachable over its public endpoint. Placing ACR behind a private network (private endpoint with public network access disabled) isn't currently supported. For the full list of network constraints, see [Limitations](../how-to/virtual-networks.md#limitations).
 
-The registry's `azureADAuthenticationAsArmPolicy` policy must be set to `enabled`.
+The registry's `azureADAuthenticationAsArmPolicy` policy status must be set to `enabled`. To check or update the status, use [`az acr config authentication-as-arm`](/cli/azure/acr/config/authentication-as-arm).
 
 | Built-in role | Scope | Can assignee create a container registry? |
 | --- | --- | --- |

--- a/articles/foundry/agents/concepts/hosted-agent-permissions.md
+++ b/articles/foundry/agents/concepts/hosted-agent-permissions.md
@@ -192,6 +192,8 @@ Creating an Azure Container Registry requires the `Microsoft.ContainerRegistry/r
 > [!NOTE]
 > For Hosted agents, the container registry must currently be reachable over its public endpoint. Placing ACR behind a private network (private endpoint with public network access disabled) isn't currently supported. For the full list of network constraints, see [Limitations](../how-to/virtual-networks.md#limitations).
 
+The registry must have the `azureADAuthenticationAsArmPolicy` policy set to `enabled`.
+
 | Built-in role | Scope | Can assignee create a container registry? |
 | --- | --- | --- |
 | Owner | Resource group | ✔ Yes |

--- a/articles/foundry/agents/concepts/hosted-agent-permissions.md
+++ b/articles/foundry/agents/concepts/hosted-agent-permissions.md
@@ -191,7 +191,6 @@ Creating an Azure Container Registry requires the `Microsoft.ContainerRegistry/r
 
 > [!NOTE]
 > For Hosted agents, the container registry must currently be reachable over its public endpoint. Placing ACR behind a private network (private endpoint with public network access disabled) isn't currently supported. For the full list of network constraints, see [Limitations](../how-to/virtual-networks.md#limitations).
-
 > The registry's `azureADAuthenticationAsArmPolicy` policy status must be set to `enabled`. This setting allows ACR to accept Microsoft Entra tokens scoped to Azure Resource Manager. To check or update the status, use [`az acr config authentication-as-arm`](/cli/azure/acr/config/authentication-as-arm).
 
 | Built-in role | Scope | Can assignee create a container registry? |

--- a/articles/foundry/agents/concepts/hosted-agent-permissions.md
+++ b/articles/foundry/agents/concepts/hosted-agent-permissions.md
@@ -192,7 +192,7 @@ Creating an Azure Container Registry requires the `Microsoft.ContainerRegistry/r
 > [!NOTE]
 > For Hosted agents, the container registry must currently be reachable over its public endpoint. Placing ACR behind a private network (private endpoint with public network access disabled) isn't currently supported. For the full list of network constraints, see [Limitations](../how-to/virtual-networks.md#limitations).
 
-The registry's `azureADAuthenticationAsArmPolicy` policy status must be set to `enabled`. This setting allows ACR to accept Microsoft Entra tokens scoped to Azure Resource Manager. To check or update the status, use [`az acr config authentication-as-arm`](/cli/azure/acr/config/authentication-as-arm).
+> The registry's `azureADAuthenticationAsArmPolicy` policy status must be set to `enabled`. This setting allows ACR to accept Microsoft Entra tokens scoped to Azure Resource Manager. To check or update the status, use [`az acr config authentication-as-arm`](/cli/azure/acr/config/authentication-as-arm).
 
 | Built-in role | Scope | Can assignee create a container registry? |
 | --- | --- | --- |

--- a/articles/foundry/agents/concepts/hosted-agent-permissions.md
+++ b/articles/foundry/agents/concepts/hosted-agent-permissions.md
@@ -191,6 +191,7 @@ Creating an Azure Container Registry requires the `Microsoft.ContainerRegistry/r
 
 > [!NOTE]
 > For Hosted agents, the container registry must currently be reachable over its public endpoint. Placing ACR behind a private network (private endpoint with public network access disabled) isn't currently supported. For the full list of network constraints, see [Limitations](../how-to/virtual-networks.md#limitations).
+>
 > The registry's `azureADAuthenticationAsArmPolicy` policy status must be set to `enabled`. This setting allows ACR to accept Microsoft Entra tokens scoped to Azure Resource Manager. To check or update the status, use [`az acr config authentication-as-arm`](/cli/azure/acr/config/authentication-as-arm).
 
 | Built-in role | Scope | Can assignee create a container registry? |

--- a/articles/foundry/agents/concepts/hosted-agent-permissions.md
+++ b/articles/foundry/agents/concepts/hosted-agent-permissions.md
@@ -192,7 +192,7 @@ Creating an Azure Container Registry requires the `Microsoft.ContainerRegistry/r
 > [!NOTE]
 > For Hosted agents, the container registry must currently be reachable over its public endpoint. Placing ACR behind a private network (private endpoint with public network access disabled) isn't currently supported. For the full list of network constraints, see [Limitations](../how-to/virtual-networks.md#limitations).
 
-The registry must have the `azureADAuthenticationAsArmPolicy` policy set to `enabled`.
+The registry's `azureADAuthenticationAsArmPolicy` policy must be set to `enabled`.
 
 | Built-in role | Scope | Can assignee create a container registry? |
 | --- | --- | --- |

--- a/articles/foundry/agents/how-to/deploy-hosted-agent.md
+++ b/articles/foundry/agents/how-to/deploy-hosted-agent.md
@@ -568,7 +568,7 @@ Provisioning errors surface on the version object's `error.code` and `error.mess
 
 | Error code | HTTP code | Solution |
 | ------------ | ----------- | ---------- |
-| `image_pull_failed` | 400 | Verify the image URI, registry RBAC, and ACR authentication policy. The project managed identity needs **Container Registry Repository Reader** on the ACR, and the registry's `azureADAuthenticationAsArmPolicy` policy status must be `enabled` |
+| `image_pull_failed` | 400 | Verify the image URI. Confirm that the project managed identity has **Container Registry Repository Reader** on the ACR and that the registry's `azureADAuthenticationAsArmPolicy` policy status is `enabled` |
 | `SubscriptionIsNotRegistered` | 400 | Register the subscription provider |
 | `InvalidAcrPullCredentials` | 401 | Fix managed identity or registry RBAC |
 | `UnauthorizedAcrPull` | 403 | Provide correct credentials or identity |

--- a/articles/foundry/agents/how-to/deploy-hosted-agent.md
+++ b/articles/foundry/agents/how-to/deploy-hosted-agent.md
@@ -568,7 +568,7 @@ Provisioning errors surface on the version object's `error.code` and `error.mess
 
 | Error code | HTTP code | Solution |
 | ------------ | ----------- | ---------- |
-| `image_pull_failed` | 400 | Verify the image URI is correct, the project managed identity has **Container Registry Repository Reader** on the ACR, and the registry's `azureADAuthenticationAsArmPolicy` policy is set to `enabled` |
+| `image_pull_failed` | 400 | Verify the image URI, registry RBAC, and ACR authentication policy. The project managed identity needs **Container Registry Repository Reader** on the ACR, and the registry's `azureADAuthenticationAsArmPolicy` policy status must be `enabled` |
 | `SubscriptionIsNotRegistered` | 400 | Register the subscription provider |
 | `InvalidAcrPullCredentials` | 401 | Fix managed identity or registry RBAC |
 | `UnauthorizedAcrPull` | 403 | Provide correct credentials or identity |

--- a/articles/foundry/agents/how-to/deploy-hosted-agent.md
+++ b/articles/foundry/agents/how-to/deploy-hosted-agent.md
@@ -568,7 +568,7 @@ Provisioning errors surface on the version object's `error.code` and `error.mess
 
 | Error code | HTTP code | Solution |
 | ------------ | ----------- | ---------- |
-| `image_pull_failed` | 400 | Verify the image URI is correct and the project managed identity has **Container Registry Repository Reader** on the ACR |
+| `image_pull_failed` | 400 | Verify the image URI is correct, the project managed identity has **Container Registry Repository Reader** on the ACR, and the registry's `azureADAuthenticationAsArmPolicy` policy is set to `enabled` |
 | `SubscriptionIsNotRegistered` | 400 | Register the subscription provider |
 | `InvalidAcrPullCredentials` | 401 | Fix managed identity or registry RBAC |
 | `UnauthorizedAcrPull` | 403 | Provide correct credentials or identity |


### PR DESCRIPTION
Deploying Foundry hosted agents using a Container Registry with `azureADAuthenticationAsArmPolicy: disabled` results in Foundry failing to pull the image:

```
"error": {
    "code": "ImageError",
    "message": "Failed to pull container image. Please check the image URI and ACR permissions, then retry. (image: <acrname>.azurecr.io) For troubleshooting, see https://aka.ms/hostedagents/tsg/image"
  },
```

but this requirement does not seem to currently be documented.