### PR TITLE
Fixed commands for disabling/enabling web search

### DIFF
--- a/articles/foundry/openai/includes/how-to-web-search-content.md
+++ b/articles/foundry/openai/includes/how-to-web-search-content.md
@@ -877,7 +877,7 @@ Before running the following commands, make sure you have the following prerequi
 To disable the `web_search` tool for all accounts in a subscription:
 
 ```bash
-az feature register --name OpenAI.BlockedTools.web_search --namespace Microsoft.CognitiveServices --subscription "<subscription-id>"
+az feature unregister --name OpenAI.BlockedTools.web_search --namespace Microsoft.CognitiveServices --subscription "<subscription-id>"
 ```
 
 This command disables web search across all accounts in the specified subscription.
@@ -887,7 +887,7 @@ This command disables web search across all accounts in the specified subscripti
 To enable the `web_search` tool:
 
 ```bash
-az feature unregister --name OpenAI.BlockedTools.web_search --namespace Microsoft.CognitiveServices --subscription "<subscription-id>"
+az feature register --name OpenAI.BlockedTools.web_search --namespace Microsoft.CognitiveServices --subscription "<subscription-id>"
 ```
 
 This command enables Bing web search functionality for all accounts in the subscription.


### PR DESCRIPTION
The az cli commands for enabling/disabling (register/unregister) the web search tool were swapped. The register command was in the disable section and unregister was in enable section. This is now swapped and fixed.