### PR TITLE
docs(search): add missing RBAC enable step in knowledge base Configure access section

### DIFF
--- a/articles/search/agentic-retrieval-how-to-create-knowledge-base.md
+++ b/articles/search/agentic-retrieval-how-to-create-knowledge-base.md
@@ -107,6 +107,9 @@ Azure AI Search needs access to the LLM from Azure OpenAI in Foundry Models. We 
 
 ### [**Use roles**](#tab/rbac)
 
+> [!IMPORTANT]
+> Before using Microsoft Entra ID credentials, [enable role-based access control](search-security-enable-roles.md) on your Azure AI Search service. By default, search services are created in API key-only authentication mode. Microsoft Entra ID tokens—including those issued by `DefaultAzureCredential`—are rejected with a `403 Forbidden` error until role-based access is enabled on the service.
+
 ::: zone pivot="csharp"
 
 1. [Configure Azure AI Search to use a managed identity](search-how-to-managed-identities.md).

--- a/articles/search/agentic-retrieval-how-to-create-knowledge-base.md
+++ b/articles/search/agentic-retrieval-how-to-create-knowledge-base.md
@@ -107,10 +107,9 @@ Azure AI Search needs access to the LLM from Azure OpenAI in Foundry Models. We 
 
 ### [**Use roles**](#tab/rbac)
 
-> [!IMPORTANT]
-> Before using Microsoft Entra ID credentials, [enable role-based access control](search-security-enable-roles.md) on your Azure AI Search service. By default, search services are created in API key-only authentication mode. Microsoft Entra ID tokens—including those issued by `DefaultAzureCredential`—are rejected with a `403 Forbidden` error until role-based access is enabled on the service.
-
 ::: zone pivot="csharp"
+
+1. [Enable role-based access control on Azure AI Search](search-security-enable-roles.md).
 
 1. [Configure Azure AI Search to use a managed identity](search-how-to-managed-identities.md).
 
@@ -130,6 +129,8 @@ Azure AI Search needs access to the LLM from Azure OpenAI in Foundry Models. We 
 
 ::: zone pivot="python"
 
+1. [Enable role-based access control on Azure AI Search](search-security-enable-roles.md).
+
 1. [Configure Azure AI Search to use a managed identity](search-how-to-managed-identities.md).
 
 1. On your model provider, assign **Cognitive Services User** to the managed identity of your search service. If you're testing locally, assign the same role to your user account.
@@ -145,6 +146,8 @@ Azure AI Search needs access to the LLM from Azure OpenAI in Foundry Models. We 
 ::: zone-end
 
 ::: zone pivot="rest"
+
+1. [Enable role-based access control on Azure AI Search](search-security-enable-roles.md).
 
 1. [Configure Azure AI Search to use a managed identity](search-how-to-managed-identities.md).
 


### PR DESCRIPTION
## Summary

The **Configure access > Use roles** section of `agentic-retrieval-how-to-create-knowledge-base.md` shows `DefaultAzureCredential` and other Microsoft Entra ID token-based patterns but does not include a prerequisite to enable role-based access control on the Azure AI Search service itself.

By default, Azure AI Search is created in `apiKeyOnly` authentication mode. In this mode, Microsoft Entra ID tokens are rejected with a `403 Forbidden` response at the service level, regardless of whether roles are correctly assigned. This behaviour is not signalled in the Configure access section, so developers who assign the right roles and write the correct credential code still encounter a 403 until they separately discover the need to change the service authentication option.

The quickstart setup include (`includes/quickstarts/agentic-retrieval-setup.md`) already covers this step correctly under "Enable role-based access". The how-to doc does not.

## Change

Added an `[!IMPORTANT]` callout immediately under the `Use roles` tab header, before the SDK-specific steps, linking to `search-security-enable-roles.md` and explaining the default `apiKeyOnly` behaviour and the `403 Forbidden` symptom.

The callout applies to all SDK zones (C#, Python, REST) because it sits outside any zone pivot block.

## Test plan

- [ ] Callout renders correctly in the docs build
- [ ] Link to `search-security-enable-roles.md` resolves correctly
- [ ] No existing content was changed, only the new callout block was inserted