### PR TITLE
Fix deprecated Microsoft Docs link in Content Understanding markdown article

### DIFF
--- a/articles/ai-services/content-understanding/document/markdown.md
+++ b/articles/ai-services/content-understanding/document/markdown.md
@@ -236,7 +236,7 @@ Contact our support team at [support@contoso.com](mailto:support@contoso.com "Em
 
 See the [official documentation][docs] for detailed instructions.
 
-[docs]: https://docs.microsoft.com
+[docs]: https://learn.microsoft.com
 ```
 
 ## Annotations


### PR DESCRIPTION
This PR updates a deprecated docs.microsoft.com reference link to the current learn.microsoft.com domain in the Content Understanding markdown article.

The change is limited to documentation link maintenance and does not modify technical guidance or sample behavior.