### PR TITLE
Clarify input size constraints for gpt-image-2 images

### DIFF
--- a/articles/foundry/openai/how-to/dall-e.md
+++ b/articles/foundry/openai/how-to/dall-e.md
@@ -144,7 +144,7 @@ For `gpt-image-2`, arbitrary resolutions are supported with the following constr
 - Total pixel count between 655,360 and 8,294,400.
 
 > [!NOTE]
-> The constraints apply only to explicitly specified sizes. If size=auto, the generated image may have dimensions that do not satisfy these constraints (for example, an edge may not be a multiple of 16 pixels).
+> The sizing constraints only apply when you specify a size. If `size=auto`, the generated image may have dimensions that do not satisfy these constraints (for example, an edge might not be a multiple of 16 pixels).
 
 #### Quality
 

--- a/articles/foundry/openai/how-to/dall-e.md
+++ b/articles/foundry/openai/how-to/dall-e.md
@@ -144,7 +144,7 @@ For `gpt-image-2`, arbitrary resolutions are supported with the following constr
 - Total pixel count between 655,360 and 8,294,400.
 
 > [!NOTE]
-> The constraints apply to the input size parameter - the generated output image is not guaranteed to satisfy the same constraints (e.g. the edges may not be a multiple of 16 pixels)
+> The constraints apply only to explicitly specified sizes. If size=auto, the generated image may have dimensions that do not satisfy these constraints (for example, an edge may not be a multiple of 16 pixels).
 
 #### Quality
 

--- a/articles/foundry/openai/how-to/dall-e.md
+++ b/articles/foundry/openai/how-to/dall-e.md
@@ -143,6 +143,9 @@ For `gpt-image-2`, arbitrary resolutions are supported with the following constr
 - Aspect ratio up to 3:1.
 - Total pixel count between 655,360 and 8,294,400.
 
+> [!NOTE]
+> The constraints apply to the input size parameter - the generated output image is not guaranteed to satisfy the same constraints (e.g. the edges may not be a multiple of 16 pixels)
+
 #### Quality
 
 There are three options for image quality: `low`, `medium`, and `high`. Lower quality images can be generated faster.


### PR DESCRIPTION
Added note about input size constraints for image generation.