### PR TITLE
Add Python SDK workflows to hosted agent quickstarts

### DIFF
--- a/articles/foundry/agents/quickstarts/quickstart-hosted-agent.md
+++ b/articles/foundry/agents/quickstarts/quickstart-hosted-agent.md
@@ -1,9 +1,9 @@
 ---
 title: "Quickstart: Deploy your first hosted agent"
-description: "Learn how to deploy a containerized AI agent to Foundry Agent Service using the Azure Developer CLI, Microsoft Foundry Toolkit for Visual Studio Code extension, or Microsoft Foundry Skill."
+description: "Learn how to deploy a containerized AI agent to Foundry Agent Service using the Azure Developer CLI, the Python SDK, Microsoft Foundry Toolkit for Visual Studio Code extension, or Microsoft Foundry Skill."
 author: aahill
 ms.author: aahi
-ms.date: 07/01/2026
+ms.date: 07/09/2026
 ms.manager: mcleans
 ms.topic: quickstart
 ms.service: microsoft-foundry
@@ -31,6 +31,24 @@ Before you begin, you need:
     ```
     azd ext install microsoft.foundry
     ```
+
+:::zone-end
+
+:::zone pivot="python"
+
+* [Azure CLI](/cli/azure/install-azure-cli) installed and authenticated:
+
+  ```bash
+  az login
+  ```
+
+* The Python SDK packages used in this quickstart:
+
+  ```bash
+  pip install "azure-ai-projects>=2.3.0" python-dotenv
+  ```
+
+* An existing Foundry project with a deployed model. The Python SDK path in this quickstart creates and routes a hosted agent version, but it doesn't scaffold a new Foundry project or create a model deployment for you. If you need the full provisioning workflow, use the Azure Developer CLI tab in this article.
 
 :::zone-end
 
@@ -138,6 +156,207 @@ Deploying services (azd deploy)
 
 :::zone-end
 
+:::zone pivot="python"
+
+## Step 1: Create or choose a Foundry project
+
+1. Open [Azure AI Foundry](https://ai.azure.com) and create a Foundry project, or select an existing one.
+1. In the project, deploy a chat-capable model such as `gpt-5.4-mini`.
+1. Copy these values from the portal:
+  * **Project endpoint** from **Overview**.
+  * **Deployment name** from **Build** > **Deployments**.
+
+## Step 2: Download the Basic sample agent code
+
+Clone the Foundry samples repo.
+
+```bash
+git clone https://github.com/microsoft-foundry/foundry-samples.git
+```
+
+For Windows (PowerShell):
+
+```powershell
+git clone https://github.com/microsoft-foundry/foundry-samples.git
+```
+
+## Step 3: Create a Python environment and configure settings
+
+Create a virtual environment and install the Python packages required for this quickstart.
+
+For macOS or Linux:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install "azure-ai-projects>=2.3.0" python-dotenv
+```
+
+For Windows (PowerShell):
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install "azure-ai-projects>=2.3.0" python-dotenv
+```
+
+Create a working folder for the deployment script, then create a `.env` file in that folder:
+
+```text
+FOUNDRY_PROJECT_ENDPOINT=<your-project-endpoint>
+FOUNDRY_MODEL_NAME=<your-model-deployment-name>
+FOUNDRY_HOSTED_AGENT_NAME=basic-agent
+FOUNDRY_SAMPLE_PATH=<full-path-to-foundry-samples/samples/python/hosted-agents/agent-framework/responses/01-basic>
+```
+
+## Step 4: Deploy the hosted agent with Python
+
+Create a file named `deploy_hosted_agent.py` in the same working folder as `.env` with the following contents:
+
+```python
+import os
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import (
+  AgentEndpointConfig,
+  CodeConfiguration,
+  CodeDependencyResolution,
+  FixedRatioVersionSelectionRule,
+  HostedAgentDefinition,
+  ProtocolConfiguration,
+  ProtocolVersionRecord,
+  ResponsesProtocolConfiguration,
+  VersionSelector,
+)
+
+load_dotenv()
+
+endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+model_name = os.environ["FOUNDRY_MODEL_NAME"]
+agent_name = os.environ.get("FOUNDRY_HOSTED_AGENT_NAME", "basic-agent")
+sample_path = Path(os.environ["FOUNDRY_SAMPLE_PATH"]).resolve()
+
+
+def create_code_zip(source_dir: Path) -> Path:
+  zip_path = Path(tempfile.gettempdir()) / f"{agent_name}.zip"
+  excluded = {".git", ".venv", "__pycache__", ".env", "deploy_hosted_agent.py"}
+
+  with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
+    for path in source_dir.rglob("*"):
+      if not path.is_file():
+        continue
+      if any(part in excluded for part in path.parts):
+        continue
+      zip_file.write(path, path.relative_to(source_dir))
+
+  return zip_path
+
+
+def wait_for_active_version(project_client: AIProjectClient, version: str) -> None:
+  for attempt in range(60):
+    time.sleep(10)
+    details = project_client.agents.get_version(agent_name=agent_name, agent_version=version)
+    status = details["status"]
+    print(f"Provisioning status: {status} (attempt {attempt + 1}/60)")
+
+    if status == "active":
+      return
+
+    if status == "failed":
+      raise RuntimeError(f"Hosted agent provisioning failed: {dict(details)}")
+
+  raise RuntimeError("Timed out waiting for the hosted agent version to become active.")
+
+
+code_zip_path = create_code_zip(sample_path)
+
+with (
+  code_zip_path.open("rb") as code_stream,
+  DefaultAzureCredential() as credential,
+  AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
+):
+  original_agent_endpoint = None
+  created = None
+
+  try:
+    created = project_client.agents.create_version_from_code(
+      agent_name=agent_name,
+      description="Basic hosted agent deployed from local Python source.",
+      definition=HostedAgentDefinition(
+        cpu="0.5",
+        memory="1Gi",
+        code_configuration=CodeConfiguration(
+          runtime="python_3_14",
+          entry_point=["python", "main.py"],
+          dependency_resolution=CodeDependencyResolution.REMOTE_BUILD,
+        ),
+        environment_variables={
+          "FOUNDRY_PROJECT_ENDPOINT": endpoint,
+          "FOUNDRY_MODEL_NAME": model_name,
+        },
+        protocol_versions=[ProtocolVersionRecord(protocol="responses", version="2.0.0")],
+      ),
+      code=code_stream,
+    )
+
+    print(f"Created hosted agent version {created.version}")
+
+    wait_for_active_version(project_client, created.version)
+
+    original_agent_endpoint = project_client.agents.get(agent_name=agent_name).agent_endpoint
+    project_client.agents.update_details(
+      agent_name=agent_name,
+      agent_endpoint=AgentEndpointConfig(
+        version_selector=VersionSelector(
+          version_selection_rules=[
+            FixedRatioVersionSelectionRule(agent_version=created.version, traffic_percentage=100),
+          ]
+        ),
+        protocol_configuration=ProtocolConfiguration(responses=ResponsesProtocolConfiguration()),
+      ),
+    )
+
+    print(f"Agent endpoint configured for version {created.version}")
+
+    with project_client.get_openai_client(agent_name=agent_name) as openai_client:
+      response = openai_client.responses.create(
+        input="Write a haiku about deploying cloud applications.",
+      )
+
+    print(f"Agent response: {response.output_text}")
+  finally:
+    if original_agent_endpoint is not None:
+      project_client.agents.update_details(agent_name=agent_name, agent_endpoint=original_agent_endpoint)
+      print("Agent endpoint restored")
+
+    if created is not None:
+      project_client.agents.delete_version(agent_name=agent_name, agent_version=created.version, force=True)
+      print(f"Deleted hosted agent version {created.version}")
+```
+
+Run the script:
+
+```bash
+python deploy_hosted_agent.py
+```
+
+The script zips the sample source, uploads it as a new hosted-agent version, waits for provisioning to complete, temporarily routes the hosted agent endpoint to that version, invokes the deployed agent, and then restores the previous endpoint configuration and deletes the temporary version.
+
+## Step 5: Invoke your agent
+
+After the script completes, use the hosted agent in either of these ways:
+
+1. Edit `deploy_hosted_agent.py` and change the `input` value passed to `openai_client.responses.create(...)`, then run the script again.
+1. If you want a persistent routed version instead of a temporary validation deployment, adapt the script to skip the restore and `delete_version(...)` steps after you review the traffic-routing implications.
+
+:::zone-end
+
 :::zone pivot="vscode"
 
 ## Step 1: Create a Foundry project
@@ -220,6 +439,16 @@ When deployment completes, the agent appears under **Hosted Agents (Preview)** i
 
 1. In the Foundry Toolkit explorer, expand **Hosted Agents (Preview)** and select your agent. The detail page shows the status under **Deployment Details**.
 1. Select the **Playground** tab and send a test prompt such as `Write a haiku about deploying cloud applications.`.
+
+:::zone-end
+
+:::zone pivot="python"
+
+1. If you used the sample script as written, it already restores the endpoint configuration and deletes the temporary hosted agent version after validation.
+1. If you created a dedicated resource group for this quickstart, you can delete the resource group from the Azure portal after you no longer need the project or model deployment.
+
+> [!WARNING]
+> Deleting the resource group permanently removes everything in it, including the Foundry project, model deployments, Container Registry, Application Insights, and the hosted agent.
 
 :::zone-end
 
@@ -366,6 +595,7 @@ in this article or delete the resource group from the Azure portal.
 | `AuthorizationFailed` during provisioning | Request the **Contributor** role on the subscription or resource group. |
 | `AuthenticationError` or `DefaultAzureCredential` failure | To refresh credentials, run `azd auth logout` and then `azd auth login`. |
 | `ResourceNotFound` or `DeploymentNotFound` | Verify the endpoint URL and model deployment name in the Foundry portal under **Build** > **Deployments**. |
+| `create_version_from_code` fails with `Hosted agent provisioning failed` | Check that `main.py` and `requirements.txt` are at the root of the zip you uploaded, and verify that the model deployment name in `.env` exists in the target Foundry project. |
 | `Connection refused` on local run | Ensure no other process is using port 8088. |
 | `azd ai agent init` fails | Run `azd version` to verify 1.25.0 or later. Update with `winget upgrade Microsoft.Azd` (Windows) or `brew upgrade azd` (macOS). Run `azd ext list` and upgrade the agent extension with `azd ext upgrade azure.ai.agents` to get 0.1.34-preview or later. |
 | Microsoft Foundry Toolkit extension not found | Install the [Microsoft Foundry Toolkit for Visual Studio Code](https://aka.ms/foundrytk) from the Marketplace and switch to the prerelease channel. |
@@ -380,9 +610,10 @@ For the full permission and role-assignment matrix, see [Hosted agent permission
 In this quickstart, you:
 
 * Scaffolded a hosted agent project from the Basic agent sample.
+* Uploaded and routed a hosted agent version with the Python SDK or scaffolded the sample with Azure Developer CLI.
 * Tested the agent locally.
 * Deployed the agent to Foundry Agent Service.
-* Sent test prompts from Azure Developer CLI, VS Code, or a coding agent that
+* Sent test prompts from the Python SDK, Azure Developer CLI, VS Code, or a coding agent that
   uses the Microsoft Foundry Skill.
 
 ## Next step

--- a/articles/foundry/agents/quickstarts/quickstart-memory-hosted-agent.md
+++ b/articles/foundry/agents/quickstarts/quickstart-memory-hosted-agent.md
@@ -3,13 +3,14 @@ title: "Quickstart: Give a hosted agent persistent memory"
 description: "Provision a Foundry memory store, then deploy a Python hosted agent that remembers facts about each user across sessions by using FoundryMemoryProvider."
 author: aahill
 ms.author: aahi
-ms.date: 07/07/2026
+ms.date: 07/09/2026
 ms.manager: mcleans
 ms.topic: quickstart
 ms.service: microsoft-foundry
 ms.subservice: foundry-agent-service
 ms.custom: mode-other, dev-focus, doc-kit-assisted
 ai-usage: ai-assisted
+zone_pivot_groups: hosted-agent-quickstart-method
 # customer intent: As a developer, I want to add a persistent memory store to my hosted agent so that it remembers facts a user shared in earlier sessions.
 ---
 
@@ -21,18 +22,38 @@ In this quickstart, you give a [hosted agent](../concepts/hosted-agents.md) pers
 
 You complete two parts:
 
-- **Provision a memory store** with a single command. A bundled provisioning hook runs after `azd provision` to create the store and wire it to the agent. The store uses a chat model and an embedding model to extract and index user-profile memories.
+- **Provision a memory store** and wire it to the agent. In the Azure Developer CLI path, a bundled provisioning hook runs after `azd provision`. In the Python path, you create the store directly with the SDK. The store uses a chat model and an embedding model to extract and index user-profile memories.
 - **Deploy a hosted agent** that reads and writes the store through `FoundryMemoryProvider`. The provider retrieves relevant memories before each model call and updates the store with new facts after each turn.
 
-The agent code, memory provider, provisioning hook, and authentication come from the Foundry memory sample, so you focus on the workflow rather than the implementation.
+The agent code, memory provider, and authentication come from the Foundry memory sample, so you focus on the workflow rather than the implementation.
 
 ## Prerequisites
 
 This quickstart builds on the hosted-agent toolchain. Complete the [Prerequisites](quickstart-hosted-agent.md#prerequisites) in the hosted agent quickstart first, which cover the Azure subscription, project roles, Python, the Azure Developer CLI (`azd`), and the `microsoft.foundry` extension.
 
+:::zone pivot="azd"
+
+You use Azure Developer CLI in this path to scaffold the sample, provision the memory store through a bundled `postprovision` hook, run the agent locally, and deploy it.
+
+:::zone-end
+
+:::zone pivot="python"
+
+You use the Python SDK in this path to create the memory store with `AIProjectClient.beta.memory_stores.create(...)`, upload the hosted-agent code as a new version, route traffic to it temporarily, and validate that the same signed-in user is remembered across separate calls.
+
+Install the Python packages used in this path:
+
+```bash
+pip install "azure-ai-projects>=2.3.0" azure-identity python-dotenv
+```
+
+:::zone-end
+
 You also need an embedding model deployment in your Foundry project, such as `text-embedding-3-small`. The memory store uses it to index memories. The agent's chat model, such as `gpt-4o`, can be the deployment you already use for hosted agents.
 
-Your identity also needs the **Cognitive Services OpenAI User** role on the Foundry project scope, in addition to the roles in the hosted agent prerequisites. The memory store uses this role to call the embedding deployment. Without it, memory writes fail with a `401` error and the store stays empty.
+Your identity needs the **Foundry User** role on the Foundry project scope through the hosted-agent prerequisites, and it also needs the **Cognitive Services OpenAI User** role on the same scope. The memory store uses Foundry project data-plane access plus the embedding deployment. Without the OpenAI role, memory writes fail with a `401` error and the store stays empty.
+
+:::zone pivot="azd"
 
 ## Step 1: Initialize the hosted agent
 
@@ -87,6 +108,8 @@ The hook is self-locating and idempotent. It runs correctly no matter which dire
 - Creates the memory store with the user-profile capability enabled and verifies it on the service.
 - Sets `MEMORY_STORE_NAME` so the agent reads and writes that store. The hook persists the name to your `azd` environment for local runs and into the service environment in `azure.yaml` so `azd deploy` ships it to the container.
 
+The CLI path doesn't show a separate `create memory store` command because the bundled hook runs that creation logic for you as part of `azd provision`.
+
 The hook defaults the store name to `agent_framework_memory`. To use a different name, set it before you provision:
 
 ```powershell
@@ -139,9 +162,255 @@ azd ai agent invoke --new-session "What's my name, and is there any food I shoul
 
 The deployed agent answers with the remembered name and allergy.
 
+:::zone-end
+
+:::zone pivot="python"
+
+## Step 1: Create or choose a Foundry project
+
+1. Open [Azure AI Foundry](https://ai.azure.com) and create a Foundry project, or select an existing one.
+1. In the project, deploy:
+   * A chat-capable model such as `gpt-5.4-mini`.
+   * An embedding model such as `text-embedding-3-small`.
+1. Copy the project endpoint from **Overview** and the deployment names from **Build** > **Deployments**.
+
+## Step 2: Download the Foundry memory sample
+
+Clone the Foundry samples repo:
+
+```bash
+git clone https://github.com/microsoft-foundry/foundry-samples.git
+```
+
+Create a working folder for the deployment scripts. In that folder, create a `.env` file with these values:
+
+```text
+FOUNDRY_PROJECT_ENDPOINT=<your-project-endpoint>
+AZURE_AI_MODEL_DEPLOYMENT_NAME=<your-chat-model-deployment-name>
+AZURE_AI_EMBEDDING_MODEL_DEPLOYMENT_NAME=<your-embedding-model-deployment-name>
+FOUNDRY_HOSTED_AGENT_NAME=memory-agent
+MEMORY_STORE_NAME=agent_framework_memory
+FOUNDRY_SAMPLE_PATH=<full-path-to-foundry-samples/samples/python/hosted-agents/agent-framework/responses/13-foundry-memory/src/agent-framework-agent-foundry-memory-responses>
+```
+
+## Step 3: Provision the memory store with Python
+
+This script is safe to rerun. It first calls `get(...)` to see whether the memory store already exists. Only if the store isn't found does it call `create(...)`.
+
+Create a file named `provision_memory_store.py` in the same working folder as `.env`:
+
+```python
+import asyncio
+import os
+
+from azure.ai.projects.aio import AIProjectClient
+from azure.ai.projects.models import MemoryStoreDefaultDefinition, MemoryStoreDefaultOptions
+from azure.core.exceptions import ResourceNotFoundError
+from azure.identity.aio import DefaultAzureCredential
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+async def main() -> None:
+    endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+    memory_store_name = os.environ["MEMORY_STORE_NAME"]
+    chat_model = os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME"]
+    embedding_model = os.environ["AZURE_AI_EMBEDDING_MODEL_DEPLOYMENT_NAME"]
+
+    async with (
+        DefaultAzureCredential() as credential,
+        AIProjectClient(endpoint=endpoint, credential=credential, allow_preview=True) as project,
+    ):
+        try:
+            existing = await project.beta.memory_stores.get(name=memory_store_name)
+            print(f"Memory store '{existing.name}' already exists (id={existing.id}); leaving as-is.")
+            return
+        except ResourceNotFoundError:
+            pass
+
+        definition = MemoryStoreDefaultDefinition(
+            chat_model=chat_model,
+            embedding_model=embedding_model,
+            options=MemoryStoreDefaultOptions(
+                chat_summary_enabled=False,
+                user_profile_enabled=True,
+                user_profile_details=(
+                    "Avoid irrelevant or sensitive data, such as age, financials, precise location, and credentials"
+                ),
+            ),
+        )
+
+        created = await project.beta.memory_stores.create(
+            name=memory_store_name,
+            description="Memory store for the hosted-agent memory quickstart",
+            definition=definition,
+        )
+        print(f"Created memory store '{created.name}' (id={created.id}).")
+
+
+asyncio.run(main())
+```
+
+Run the script:
+
+```bash
+python provision_memory_store.py
+```
+
+## Step 4: Deploy the hosted agent with Python
+
+Create a file named `deploy_memory_agent.py` in the same working folder as `.env`:
+
+```python
+import os
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import (
+    AgentEndpointConfig,
+    CodeConfiguration,
+    CodeDependencyResolution,
+    FixedRatioVersionSelectionRule,
+    HostedAgentDefinition,
+    ProtocolConfiguration,
+    ProtocolVersionRecord,
+    ResponsesProtocolConfiguration,
+    VersionSelector,
+)
+from azure.identity import DefaultAzureCredential
+from dotenv import load_dotenv
+
+load_dotenv()
+
+endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+model_name = os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME"]
+agent_name = os.environ.get("FOUNDRY_HOSTED_AGENT_NAME", "memory-agent")
+memory_store_name = os.environ["MEMORY_STORE_NAME"]
+sample_path = Path(os.environ["FOUNDRY_SAMPLE_PATH"]).resolve()
+
+
+def create_code_zip(source_dir: Path) -> Path:
+    zip_path = Path(tempfile.gettempdir()) / f"{agent_name}.zip"
+    excluded = {".git", ".venv", "__pycache__", ".env"}
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        for path in source_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            if any(part in excluded for part in path.parts):
+                continue
+            zip_file.write(path, path.relative_to(source_dir))
+
+    return zip_path
+
+
+def wait_for_active_version(project_client: AIProjectClient, version: str) -> None:
+    for attempt in range(60):
+        time.sleep(10)
+        details = project_client.agents.get_version(agent_name=agent_name, agent_version=version)
+        status = details["status"]
+        print(f"Provisioning status: {status} (attempt {attempt + 1}/60)")
+
+        if status == "active":
+            return
+
+        if status == "failed":
+            raise RuntimeError(f"Hosted agent provisioning failed: {dict(details)}")
+
+    raise RuntimeError("Timed out waiting for the hosted agent version to become active.")
+
+
+code_zip_path = create_code_zip(sample_path)
+
+with (
+    code_zip_path.open("rb") as code_stream,
+    DefaultAzureCredential() as credential,
+    AIProjectClient(endpoint=endpoint, credential=credential, allow_preview=True) as project_client,
+):
+    original_agent_endpoint = None
+    created = None
+
+    try:
+        created = project_client.agents.create_version_from_code(
+            agent_name=agent_name,
+            description="Hosted agent with persistent Foundry memory.",
+            definition=HostedAgentDefinition(
+                cpu="0.5",
+                memory="1Gi",
+                code_configuration=CodeConfiguration(
+                    runtime="python_3_13",
+                    entry_point=["python", "main.py"],
+                    dependency_resolution=CodeDependencyResolution.REMOTE_BUILD,
+                ),
+                environment_variables={
+                    "FOUNDRY_PROJECT_ENDPOINT": endpoint,
+                    "AZURE_AI_MODEL_DEPLOYMENT_NAME": model_name,
+                    "MEMORY_STORE_NAME": memory_store_name,
+                },
+                protocol_versions=[ProtocolVersionRecord(protocol="responses", version="2.0.0")],
+            ),
+            code=code_stream,
+        )
+
+        print(f"Created hosted agent version {created.version}")
+        wait_for_active_version(project_client, created.version)
+
+        original_agent_endpoint = project_client.agents.get(agent_name=agent_name).agent_endpoint
+        project_client.agents.update_details(
+            agent_name=agent_name,
+            agent_endpoint=AgentEndpointConfig(
+                version_selector=VersionSelector(
+                    version_selection_rules=[
+                        FixedRatioVersionSelectionRule(agent_version=created.version, traffic_percentage=100),
+                    ]
+                ),
+                protocol_configuration=ProtocolConfiguration(responses=ResponsesProtocolConfiguration()),
+            ),
+        )
+
+        with project_client.get_openai_client(agent_name=agent_name) as openai_client:
+            first_response = openai_client.responses.create(
+                input="Hi! My name is Linda and I'm vegetarian. Please remember that.",
+            )
+            print(first_response.output_text)
+
+            time.sleep(10)
+
+            second_response = openai_client.responses.create(
+                input="Do you remember my name and any dietary preference I told you earlier?",
+            )
+            print(second_response.output_text)
+    finally:
+        if original_agent_endpoint is not None:
+            project_client.agents.update_details(agent_name=agent_name, agent_endpoint=original_agent_endpoint)
+
+        if created is not None:
+            project_client.agents.delete_version(agent_name=agent_name, agent_version=created.version, force=True)
+```
+
+Run the script:
+
+```bash
+python deploy_memory_agent.py
+```
+
+This script uploads the memory sample as a new hosted-agent version, points the hosted agent at that version temporarily, invokes it twice as the same signed-in user, and restores the previous endpoint configuration when it finishes.
+
+## Step 5: Verify that memory persists
+
+The first call stores the fact in the memory store. The second call asks for the remembered fact in a separate request. If the memory store is configured correctly, the response should mention the same name and dietary preference that you supplied in the first request.
+
+:::zone-end
+
 ## Clean up resources
 
 Delete the resources when you're finished so you stop incurring charges.
+
+:::zone pivot="azd"
 
 To delete the memory store, use the `AIProjectClient`. Run this script in a Python environment that has the `azure-ai-projects` and `azure-identity` packages installed (for example, run `pip install "azure-ai-projects>=2.3.0" azure-identity`):
 
@@ -173,13 +442,51 @@ Delete the agent and its Azure resources:
 azd down
 ```
 
+:::zone-end
+
+:::zone pivot="python"
+
+To delete the memory store, use the same script pattern with your memory store name:
+
+```python
+import asyncio
+import os
+
+from azure.ai.projects.aio import AIProjectClient
+from azure.identity.aio import DefaultAzureCredential
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+async def delete() -> None:
+    async with (
+        DefaultAzureCredential() as credential,
+        AIProjectClient(
+            endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+            credential=credential,
+            allow_preview=True,
+        ) as project,
+    ):
+        await project.beta.memory_stores.delete(os.environ["MEMORY_STORE_NAME"])
+
+
+asyncio.run(delete())
+```
+
+If you created a dedicated resource group or project for this quickstart, delete it from the Azure portal after you no longer need the chat deployment, embedding deployment, or hosted agent.
+
+:::zone-end
+
 ## Troubleshooting
 
 | Issue | Solution |
 | ----- | -------- |
 | The deployed agent has no memory, or `MEMORY_STORE_NAME` is empty | Confirm the `postprovision` hook ran during `azd provision` and that `azure.yaml` has `MEMORY_STORE_NAME` set. Rerun `azd provision` to run the hook again. |
-| Memory writes fail with a `401` error and the store stays empty | Grant the **Cognitive Services OpenAI User** role on the Foundry project scope to your identity and to the deployed agent's runtime identity. |
+| Memory writes fail with a `401` error and the store stays empty | Confirm the caller already has **Foundry User** access on the Foundry project scope, and grant the **Cognitive Services OpenAI User** role on the same scope to your identity and to the deployed agent's runtime identity. |
 | `azd provision` fails with a permissions error | Confirm your identity has the project roles listed in the [Prerequisites](quickstart-hosted-agent.md#prerequisites). |
+| `project.beta.memory_stores.create(...)` fails with `Authentication to the Azure OpenAI resource failed` | Confirm your identity already has **Foundry User** access on the Foundry project scope, and also has the **Cognitive Services OpenAI User** role on that scope. Also verify that `AZURE_AI_EMBEDDING_MODEL_DEPLOYMENT_NAME` points to a valid embedding deployment. |
+| The Python deployment succeeds but the second call doesn't recall the stored fact | Wait a few more seconds before the second call so the memory store finishes indexing, then run the script again. |
 | The agent doesn't recall a fact you shared | Allow a few seconds after storing a fact before you query, so the store finishes indexing the memory. |
 | The agent can't read or write memories after deployment | Confirm that the `postprovision` hook created the store against the same project the agent is deployed to. |
 
@@ -188,8 +495,8 @@ azd down
 In this quickstart, you:
 
 - Created a Foundry memory store with the user-profile capability.
-- Deployed a hosted agent that reads and writes to the store through `FoundryMemoryProvider`.
-- Verified that the agent recalls user facts across separate sessions, both locally and after deployment.
+- Deployed a hosted agent that reads and writes to the store through `FoundryMemoryProvider` by using Azure Developer CLI or the Python SDK.
+- Verified that the agent recalls user facts across separate sessions, either locally with Azure Developer CLI or remotely with the Python SDK after deployment.
 
 ## Next step
 

--- a/articles/foundry/agents/quickstarts/quickstart-optimize-hosted-agent.md
+++ b/articles/foundry/agents/quickstarts/quickstart-optimize-hosted-agent.md
@@ -9,6 +9,7 @@ ms.service: microsoft-foundry
 ms.subservice: foundry-agent-service
 ms.custom: mode-other, dev-focus, doc-kit-assisted
 ai-usage: ai-assisted
+zone_pivot_groups: hosted-agent-optimize-quickstart-method
 ---
 
 # Quickstart: Optimize a hosted agent (preview)
@@ -22,6 +23,9 @@ In this quickstart, you deploy the optimization sample agent, run the agent opti
 Before you begin, you need:
 
 * An Azure subscription--[Create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn).
+
+:::zone pivot="azd"
+
 * [azd CLI](https://aka.ms/azd) (Azure Developer CLI).
 * [Azure CLI](/cli/azure/install-azure-cli) for authentication.
 * The `microsoft.foundry` extension for azd (0.1.40-preview or later of the `azure.ai.agents` dependency):
@@ -36,10 +40,29 @@ Before you begin, you need:
     azd ext upgrade microsoft.foundry
     ```
 
+  :::zone-end
+
+  :::zone pivot="python"
+
+  * [azd CLI](https://aka.ms/azd) (Azure Developer CLI).
+  * [Azure CLI](/cli/azure/install-azure-cli) for authentication.
+  * Python 3.10 or later.
+  * The Python packages used in this path:
+
+    ```bash
+    pip install "azure-ai-projects>=2.3.0" azure-identity python-dotenv
+    ```
+
+  * An existing Foundry project that already contains the hosted agent, registered dataset, and evaluator you want to use for optimization.
+
+  :::zone-end
+
 * Your Azure subscription must be on the allow list for the agent optimizer. Contact your Microsoft representative to request access.
 
 > [!NOTE]
 > The agent optimizer is currently in preview.
+
+  :::zone pivot="azd"
 
 ## Step 1: Create the project
 
@@ -141,6 +164,143 @@ You can also run evaluation to confirm the score improvement:
 azd ai agent eval run
 ```
 
+:::zone-end
+
+:::zone pivot="python"
+
+## Python SDK path
+
+Use the following steps if you want to run the optimizer from Python instead of the Azure Developer CLI workflow above.
+
+This path assumes you already have the following resources in an existing Foundry project:
+
+* A hosted agent to optimize.
+* A registered training dataset.
+* A registered evaluator.
+
+Unlike the Azure Developer CLI flow above, the Python SDK path doesn't scaffold a project or generate `eval.yaml`, a dataset, or evaluators for you. If you want the sample to create those assets automatically, use `azd ai agent eval generate` first.
+
+### 1. Create a `.env` file
+
+Create a working folder, then add a `.env` file with these values:
+
+```text
+FOUNDRY_PROJECT_ENDPOINT=<your-project-endpoint>
+FOUNDRY_AGENT_NAME=<your-hosted-agent-name>
+DATASET_NAME=<your-registered-dataset-name>
+EVALUATOR_NAME=<your-registered-evaluator-name>
+DATASET_VERSION=1
+POLL_INTERVAL_SECONDS=10
+EVAL_MODEL=<your-eval-model-deployment-name>
+OPTIMIZATION_MODEL=<your-optimization-model-deployment-name>
+```
+
+Run the script from this same working folder so `load_dotenv()` can load the `.env` file automatically. If you prefer to run it from another directory, set the same values in your shell environment first.
+
+Use the exact project endpoint from your Foundry project's **Overview** page. The Python script sends its first request immediately; if `FOUNDRY_PROJECT_ENDPOINT` is only a placeholder or points to the wrong project, the run fails with `ResourceNotFound: The project does not exist`.
+
+Set `EVAL_MODEL` and `OPTIMIZATION_MODEL` to deployment names that already exist in your Foundry project, not just model family names. For example, if your project deployment is named `gpt-4.1-mini` or `DeepSeek-V3.2`, use that exact deployment name in `.env`.
+
+### 2. Run the optimization job
+
+Create a file named `optimize_hosted_agent.py` in the same folder as `.env`:
+
+```python
+import os
+import time
+
+from dotenv import load_dotenv
+
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import (
+  JobStatus,
+  OptimizationAgentIdentifier,
+  OptimizationEvaluatorRef,
+  OptimizationJob,
+  OptimizationJobInputs,
+  OptimizationOptions,
+  OptimizationReferenceDatasetInput,
+)
+
+load_dotenv()
+
+endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+agent_name = os.environ["FOUNDRY_AGENT_NAME"]
+dataset_name = os.environ["DATASET_NAME"]
+evaluator_name = os.environ["EVALUATOR_NAME"]
+dataset_version = os.environ.get("DATASET_VERSION", "1")
+poll_interval = int(os.environ.get("POLL_INTERVAL_SECONDS", "10"))
+eval_model = os.environ.get("EVAL_MODEL", "gpt-4o")
+optimization_model = os.environ.get("OPTIMIZATION_MODEL", "gpt-5")
+
+terminal_statuses = {JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.CANCELLED}
+
+with DefaultAzureCredential() as credential, AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
+  job = project_client.beta.agents.create_optimization_job(
+    job=OptimizationJob(
+      inputs=OptimizationJobInputs(
+        agent=OptimizationAgentIdentifier(agent_name=agent_name),
+        train_dataset=OptimizationReferenceDatasetInput(
+          name=dataset_name,
+          version=dataset_version,
+        ),
+        evaluators=[OptimizationEvaluatorRef(name=evaluator_name)],
+        options=OptimizationOptions(
+          max_candidates=2,
+          eval_model=eval_model,
+          optimization_model=optimization_model,
+        ),
+      )
+    )
+  )
+
+  print(f"Created optimization job: {job.id}")
+  print(f"Initial status: {job.status}")
+
+  while job.status not in terminal_statuses:
+    time.sleep(poll_interval)
+    job = project_client.beta.agents.get_optimization_job(job_id=job.id)
+    print(f"Status: {job.status}")
+
+  if job.status == JobStatus.FAILED:
+    message = job.error.message if job.error else "<no error message>"
+    raise RuntimeError(f"Optimization job failed: {message}")
+
+  if job.result:
+    print(f"Baseline candidate: {job.result.baseline}")
+    print(f"Best candidate: {job.result.best}")
+
+    for candidate in job.result.candidates or []:
+      print(
+        f"{candidate.name}: candidate_id={candidate.candidate_id}, "
+        f"avg_score={candidate.avg_score:.4f}, avg_tokens={candidate.avg_tokens:.0f}"
+      )
+```
+
+Run the script:
+
+```bash
+python optimize_hosted_agent.py
+```
+
+When the job succeeds, the script prints the winning candidate and its `candidate_id`.
+
+Unlike `azd ai agent optimize`, the Python SDK flow doesn't create a local `.agent_configs/baseline/metadata.yaml` file. The optimization job metadata stays in the returned `job` object and in the Foundry service response, including the baseline candidate, best candidate, and scored candidate list.
+
+### 3. Apply the winning candidate
+
+If you're also working from the local `azd` project used in the CLI flow above, apply the winning candidate by using the `candidate_id` returned by the Python script:
+
+```bash
+azd ai agent optimize apply --candidate <candidate-id>
+azd deploy
+```
+
+If you only need to inspect the result, use the candidate scores and evaluation identifiers printed by the script to review the winning configuration in Foundry before promoting it.
+
+:::zone-end
+
 ## Clean up resources
 
 When you finish experimenting, delete the provisioned resources:
@@ -158,6 +318,9 @@ azd down --force --purge
 | --------- | ------- | ----- |
 | `azd ai agent optimize` command not found | Extension too old | Run `azd ext upgrade microsoft.foundry` to get 0.1.40-preview or later. |
 | `optimization_model is required` | Running in non-interactive mode without a model configured | Add `--optimize-model gpt-5` to the command, or set `optimization_model: gpt-5` under `options:` in `eval.yaml`. In interactive mode, the CLI prompts for model selection. |
+| Python script fails with `KeyError: 'DATASET_NAME'` or another missing variable | The script didn't load your `.env` file, or the variable is missing | Run the script from the same folder as `.env`, or export the required values in your shell before running `python optimize_hosted_agent.py`. |
+| Python script fails with `ResourceNotFound: The project does not exist` | `FOUNDRY_PROJECT_ENDPOINT` doesn't point to an existing Foundry project | Copy the project endpoint from the Foundry project's **Overview** page and update `FOUNDRY_PROJECT_ENDPOINT` in `.env`. |
+| Python script fails with `Optimization model deployment '<name>' not found` | `OPTIMIZATION_MODEL` is not the name of a deployed model in your Foundry project | Use the exact deployment name from **Build** > **Deployments**, such as an existing `gpt-5` family or DeepSeek deployment in your project. |
 | Optimization score is 0 or very low | Evaluation has many errored rows | Open the **Eval** link in the results. Fix response generation or evaluator errors, then rerun. |
 | `azd provision` fails with quota error | Subscription lacks capacity | Try a different region or request a quota increase. |
 

--- a/articles/foundry/agents/quickstarts/quickstart-toolbox-agent.md
+++ b/articles/foundry/agents/quickstarts/quickstart-toolbox-agent.md
@@ -3,7 +3,7 @@ title: "Quickstart: Build a toolbox and use it with a hosted agent"
 description: "Build a Foundry toolbox that combines web search and the Microsoft Learn MCP server, then consume it from a Python hosted agent that connects over the Model Context Protocol."
 author: aahill
 ms.author: aahi
-ms.date: 06/16/2026
+ms.date: 07/09/2026
 ms.manager: mcleans
 ms.topic: quickstart
 ms.service: microsoft-foundry
@@ -13,8 +13,6 @@ ai-usage: ai-assisted
 zone_pivot_groups: selection-toolbox-quickstart
 # customer intent: As a developer, I want to build a toolbox that combines several tools behind one endpoint so that my hosted agent can discover and call them all through a single connection.
 ---
-
-# Quickstart: Build a toolbox and use it with a hosted agent
 
 [!INCLUDE [feature-preview](../../includes/feature-preview.md)]
 
@@ -29,7 +27,25 @@ You then consume the toolbox from a [hosted agent](../concepts/hosted-agents.md)
 
 This quickstart builds on the hosted-agent toolchain. Complete the [Prerequisites](quickstart-hosted-agent.md#prerequisites) in the hosted agent quickstart first, which cover the Azure subscription, project roles, Python, the Azure Developer CLI (`azd`), and the `microsoft.foundry` extension.
 
-For the **VS Code** path, you also need [Visual Studio Code](https://code.visualstudio.com/) with the [Microsoft Foundry Toolkit](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) extension, signed in to Azure.
+:::zone pivot="python"
+
+For the Python SDK path, use the Python section later in this article instead of the Azure Developer CLI or VS Code workflow below. That path creates the toolbox with `project_client.toolboxes.create_version(...)`, then uploads the hosted-agent code as a new version and points it at that toolbox by name.
+
+Install the Python packages used in this path:
+
+```bash
+pip install "azure-ai-projects>=2.3.0" python-dotenv
+```
+
+You need an existing Foundry project with a deployed chat-capable model. The Python SDK path in this quickstart creates the toolbox and the hosted-agent version, but it doesn't scaffold a new Foundry project or create a model deployment for you.
+
+:::zone-end
+
+:::zone pivot="vscode"
+
+You also need [Visual Studio Code](https://code.visualstudio.com/) with the [Microsoft Foundry Toolkit](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) extension, signed in to Azure.
+
+:::zone-end
 
 ## Step 1: Initialize the hosted agent
 
@@ -57,8 +73,6 @@ First, point the toolbox commands at the Foundry project you selected during ini
 azd env set FOUNDRY_PROJECT_ENDPOINT "$(azd env get-value FOUNDRY_PROJECT_ENDPOINT)"
 ```
 
-:::zone pivot="azd"
-
 The sample includes a [`toolbox.yaml`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/toolbox.yaml) in `src/toolbox-agent` that defines both tools behind one endpoint. Create the toolbox from that file:
 
 ```bash
@@ -67,7 +81,7 @@ azd ai toolbox create my-toolbox --from-file ./src/toolbox-agent/toolbox.yaml
 
 The first version becomes the default version automatically. The command prints the toolbox's versioned MCP endpoint. Copy the `Endpoint` value from the output. You set it as the `TOOLBOX_ENDPOINT` environment variable in the next steps. It looks like this:
 
-```
+```text
 https://<account>.services.ai.azure.com/api/projects/<project>/toolboxes/my-toolbox/versions/1/mcp?api-version=v1
 ```
 
@@ -103,7 +117,7 @@ azd provision
 
 1. Point the local agent at your toolbox by setting these values in the `.env` file in `src/toolbox-agent`. Paste the endpoint you copied in [Step 2](#step-2-create-the-toolbox):
 
-    ```
+    ```text
     FOUNDRY_MODEL_NAME=<your-model-deployment-name>
     TOOLBOX_ENDPOINT=<versioned-endpoint-from-step-2>
     ```
@@ -140,9 +154,233 @@ When the command finishes, the output shows links to the agent playground and th
 azd ai agent invoke "What's new in Azure AI Foundry? Use the Microsoft Learn documentation."
 ```
 
+:::zone pivot="python"
+
+## Python SDK path
+
+Use the following steps if you want to create the toolbox and deploy the hosted-agent version with the Python SDK instead of the Azure Developer CLI or VS Code flow above.
+
+### 1. Create or choose a Foundry project
+
+1. Open [Azure AI Foundry](https://ai.azure.com) and create a Foundry project, or select an existing one.
+1. In the project, deploy a chat-capable model such as `gpt-5.4-mini`.
+1. Copy the project endpoint from **Overview** and the deployment name from **Build** > **Deployments**.
+
+### 2. Download the toolbox hosted-agent sample
+
+Clone the Foundry samples repo:
+
+```bash
+git clone https://github.com/microsoft-foundry/foundry-samples.git
+```
+
+Create a working folder for the deployment scripts. In that folder, create a `.env` file with these values:
+
+```text
+FOUNDRY_PROJECT_ENDPOINT=<your-project-endpoint>
+AZURE_AI_MODEL_DEPLOYMENT_NAME=<your-model-deployment-name>
+FOUNDRY_HOSTED_AGENT_NAME=toolbox-agent
+TOOLBOX_NAME=my-toolbox
+FOUNDRY_SAMPLE_PATH=<full-path-to-foundry-samples/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/src/agent-framework-agent-with-foundry-toolbox-responses>
+```
+
+## Step 3: Create the toolbox with Python
+
+Create a file named `create_toolbox.py` in the same working folder as `.env`:
+
+```python
+import os
+
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import MCPToolboxTool, WebSearchToolboxTool
+from dotenv import load_dotenv
+
+load_dotenv()
+
+endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
+toolbox_name = os.environ["TOOLBOX_NAME"]
+
+with DefaultAzureCredential() as credential, AIProjectClient(endpoint=endpoint, credential=credential) as project_client:
+    created = project_client.toolboxes.create_version(
+        name=toolbox_name,
+        description="Toolbox with web search and Microsoft Learn MCP.",
+        tools=[
+            WebSearchToolboxTool(
+                name="web_search",
+                search_context_size="medium",
+            ),
+            MCPToolboxTool(
+                server_label="mslearn",
+                server_url="https://learn.microsoft.com/api/mcp",
+                require_approval="never",
+            ),
+        ],
+    )
+    print(f"Created toolbox version {created.version} for {created.name}")
+
+    toolbox = project_client.toolboxes.get(name=toolbox_name)
+    mcp_endpoint = (
+        f"{endpoint}/toolboxes/{toolbox.name}/versions/{toolbox.default_version}/mcp?api-version=v1"
+    )
+    print(f"Default toolbox version: {toolbox.default_version}")
+    print(f"Toolbox MCP endpoint: {mcp_endpoint}")
+```
+
+Run the script:
+
+```bash
+python create_toolbox.py
+```
+
+The sample hosted agent can resolve the toolbox either from `TOOLBOX_ENDPOINT` or from `FOUNDRY_PROJECT_ENDPOINT` plus `TOOLBOX_NAME`. This path uses `TOOLBOX_NAME`, so you don't need to store the versioned endpoint in `.env`.
+
+### 4. Deploy the hosted agent with Python
+
+Create a file named `deploy_toolbox_agent.py` in the same working folder as `.env`:
+
+```python
+import os
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import (
+    AgentEndpointConfig,
+    CodeConfiguration,
+    CodeDependencyResolution,
+    FixedRatioVersionSelectionRule,
+    HostedAgentDefinition,
+    ProtocolConfiguration,
+    ProtocolVersionRecord,
+    ResponsesProtocolConfiguration,
+    VersionSelector,
+)
+from azure.identity import DefaultAzureCredential
+from dotenv import load_dotenv
+
+load_dotenv()
+
+endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+model_name = os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME"]
+agent_name = os.environ.get("FOUNDRY_HOSTED_AGENT_NAME", "toolbox-agent")
+toolbox_name = os.environ["TOOLBOX_NAME"]
+sample_path = Path(os.environ["FOUNDRY_SAMPLE_PATH"]).resolve()
+
+
+def create_code_zip(source_dir: Path) -> Path:
+    zip_path = Path(tempfile.gettempdir()) / f"{agent_name}.zip"
+    excluded = {".git", ".venv", "__pycache__", ".env"}
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        for path in source_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            if any(part in excluded for part in path.parts):
+                continue
+            zip_file.write(path, path.relative_to(source_dir))
+
+    return zip_path
+
+
+def wait_for_active_version(project_client: AIProjectClient, version: str) -> None:
+    for attempt in range(60):
+        time.sleep(10)
+        details = project_client.agents.get_version(agent_name=agent_name, agent_version=version)
+        status = details["status"]
+        print(f"Provisioning status: {status} (attempt {attempt + 1}/60)")
+
+        if status == "active":
+            return
+
+        if status == "failed":
+            raise RuntimeError(f"Hosted agent provisioning failed: {dict(details)}")
+
+    raise RuntimeError("Timed out waiting for the hosted agent version to become active.")
+
+
+code_zip_path = create_code_zip(sample_path)
+
+with (
+    code_zip_path.open("rb") as code_stream,
+    DefaultAzureCredential() as credential,
+    AIProjectClient(endpoint=endpoint, credential=credential) as project_client,
+):
+    original_agent_endpoint = None
+    created = None
+
+    try:
+        created = project_client.agents.create_version_from_code(
+            agent_name=agent_name,
+            description="Hosted agent with Foundry Toolbox integration.",
+            definition=HostedAgentDefinition(
+                cpu="1",
+                memory="2Gi",
+                code_configuration=CodeConfiguration(
+                    runtime="python_3_13",
+                    entry_point=["python", "main.py"],
+                    dependency_resolution=CodeDependencyResolution.REMOTE_BUILD,
+                ),
+                environment_variables={
+                    "FOUNDRY_PROJECT_ENDPOINT": endpoint,
+                    "AZURE_AI_MODEL_DEPLOYMENT_NAME": model_name,
+                    "TOOLBOX_NAME": toolbox_name,
+                },
+                protocol_versions=[ProtocolVersionRecord(protocol="responses", version="2.0.0")],
+            ),
+            code=code_stream,
+        )
+
+        print(f"Created hosted agent version {created.version}")
+        wait_for_active_version(project_client, created.version)
+
+        original_agent_endpoint = project_client.agents.get(agent_name=agent_name).agent_endpoint
+        project_client.agents.update_details(
+            agent_name=agent_name,
+            agent_endpoint=AgentEndpointConfig(
+                version_selector=VersionSelector(
+                    version_selection_rules=[
+                        FixedRatioVersionSelectionRule(agent_version=created.version, traffic_percentage=100),
+                    ]
+                ),
+                protocol_configuration=ProtocolConfiguration(responses=ResponsesProtocolConfiguration()),
+            ),
+        )
+
+        with project_client.get_openai_client(agent_name=agent_name) as openai_client:
+            response = openai_client.responses.create(
+                input="How do I create a hosted agent in Microsoft Foundry? Use the Microsoft Learn documentation.",
+            )
+            print(response.output_text)
+    finally:
+        if original_agent_endpoint is not None:
+            project_client.agents.update_details(agent_name=agent_name, agent_endpoint=original_agent_endpoint)
+
+        if created is not None:
+            project_client.agents.delete_version(agent_name=agent_name, agent_version=created.version, force=True)
+```
+
+Run the script:
+
+```bash
+python deploy_toolbox_agent.py
+```
+
+This script uploads the toolbox sample as a new hosted-agent version, points the hosted agent at that version temporarily, invokes it with a Microsoft Learn question, and restores the previous endpoint configuration when it finishes.
+
+### 5. Verify the toolbox-backed response
+
+If the toolbox is configured correctly, the response should show that the hosted agent discovered the toolbox tools and answered by using Microsoft Learn documentation.
+
+:::zone-end
+
 ## Clean up resources
 
 Delete the resources when you're finished so you stop incurring charges.
+
+:::zone pivot="azd"
 
 Delete the toolbox:
 
@@ -165,6 +403,32 @@ Delete the agent and its Azure resources:
 azd down
 ```
 
+:::zone-end
+
+:::zone pivot="python"
+
+Delete the toolbox by name:
+
+```python
+import os
+
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from dotenv import load_dotenv
+
+load_dotenv()
+
+with DefaultAzureCredential() as credential, AIProjectClient(
+    endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+    credential=credential,
+) as project_client:
+    project_client.toolboxes.delete(name=os.environ["TOOLBOX_NAME"])
+```
+
+If you created a dedicated resource group or project for this quickstart, delete it from the Azure portal after you no longer need the toolbox, chat deployment, or hosted agent.
+
+:::zone-end
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -179,8 +443,8 @@ azd down
 In this quickstart, you:
 
 - Built a toolbox that combines web search and the Microsoft Learn MCP server behind one endpoint.
-- Consumed the toolbox from a Python hosted agent that connects over the Model Context Protocol.
-- Ran the agent locally and deployed it to Foundry Agent Service.
+- Consumed the toolbox from a Python hosted agent that connects over the Model Context Protocol by using Azure Developer CLI or the Python SDK.
+- Ran the agent locally or validated it remotely and deployed it to Foundry Agent Service.
 
 ## Next step
 


### PR DESCRIPTION
## Summary
- add Python SDK workflows to the hosted agent, memory hosted agent, and toolbox hosted agent quickstarts
- expand prerequisites, environment setup, deployment, invocation, cleanup, and troubleshooting guidance for the new Python paths
- refresh metadata and quickstart copy to reflect the broader workflow coverage

## Testing
- not run (docs-only changes)