### PR TITLE
Promote Toolbox as the recommended way to add tools to agents

### DIFF
--- a/articles/foundry/agents/concepts/tool-catalog.md
+++ b/articles/foundry/agents/concepts/tool-catalog.md
@@ -21,6 +21,9 @@ Tools extend what your agents can do in Microsoft Foundry Agent Service. An agen
 > [!NOTE]
 > The Foundry tool catalog and the core tools framework are generally available. Some individual tools are still in preview, as noted in the tool listings throughout this article. Each tool's own page also indicates its preview status with a banner. Preview tools are subject to [supplemental terms of use](https://azure.microsoft.com/support/legal/preview-supplemental-terms/).
 
+> [!TIP]
+> **Recommended:** For most agents, add tools through a [toolbox](../how-to/tools/toolbox.md). A toolbox packages your tools behind a single managed MCP endpoint, handles credential injection and policy enforcement, and lets you version tools without changing agent code. You can still attach any tool directly to an individual agent. See the [Toolbox](#toolbox) section and [Create, test, and deploy a toolbox](../how-to/tools/toolbox.md).
+
 ## What are tools?
 
 A *tool* is a capability that an agent can invoke during a conversation to perform a specific task. When an agent receives a user message, the Foundry model powering the agent decides whether to call a tool based on the agent's instructions and the available tool definitions. The agent sends the tool request, your application or the service executes it, and the result flows back into the conversation so the agent can continue with accurate, up-to-date information.
@@ -34,7 +37,17 @@ Tools enable agents to go beyond text generation. For example, an agent can:
 
 ## Types of tools
 
-Foundry Agent Service provides two categories of tools: built-in tools that are ready to use after basic configuration, and custom tools that let you bring your own capabilities.
+Foundry Agent Service groups tools into two categories: built-in tools that are ready to use after basic configuration, and custom tools that let you bring your own capabilities. Whichever category a tool belongs to, the recommended way to make it available to an agent is through a *toolbox*—a single managed endpoint that packages and governs your tools. The following sections describe each option, starting with the recommended toolbox approach.
+
+### Toolbox
+
+**Recommended.** A *toolbox* is a curated bundle of tools - such as web search, Azure AI Search, code interpreter, file search, MCP servers, and OpenAPI tools - that you configure once and expose as a single MCP-compatible endpoint. Instead of attaching each tool individually to every agent definition, define the collection in a toolbox and connect any agent to the toolbox endpoint. Because a toolbox exposes an MCP-compatible endpoint, any MCP-capable runtime can consume it - including agents built with Microsoft Agent Framework, LangGraph, GitHub Copilot SDK, and custom code.
+
+Toolboxes support versioning. Create multiple versions, test a new version against the version-specific endpoint, and then promote it to default when it's ready. Agents that connect to the Toolbox consumer endpoint automatically receive the promoted default version without code changes. For details, see [Manage toolbox versions](../how-to/tools/toolbox.md#promote-a-version-to-default).
+
+Manage authentication for tools in a toolbox centrally. The toolbox handles credential injection, token refresh, and policy enforcement at runtime by using Microsoft Entra ID and OAuth, so consuming agents don't need to manage credentials for each tool individually. For authentication details, see [Set up MCP server authentication](../how-to/mcp-authentication.md).
+
+For setup steps, see [Create and use a Foundry Toolbox](../how-to/tools/toolbox.md). To try it end to end, see the [toolbox quickstart](../quickstarts/quickstart-toolbox-agent.md).
 
 ### Built-in tools
 
@@ -60,16 +73,6 @@ The most common custom tool options include:
 - **[OpenAPI tool](../how-to/tools/openapi.md)** — Connect your agent to external HTTP APIs by using an OpenAPI 3.0 or 3.1 specification.
 
 For the complete list of custom tool options, see [All custom tools](#all-custom-tools).
-
-### Toolbox
-
-A *toolbox* is a curated bundle of tools - such as web search, Azure AI Search, code interpreter, file search, MCP servers, and OpenAPI tools - that you configure once and expose as a single MCP-compatible endpoint. Instead of attaching each tool individually to every agent definition, define the collection in a toolbox and connect any agent to the toolbox endpoint. Because a toolbox exposes an MCP-compatible endpoint, any MCP-capable runtime can consume it - including agents built with Microsoft Agent Framework, LangGraph, GitHub Copilot SDK, and custom code.
-
-Toolboxes support versioning. Create multiple versions, test a new version against the version-specific endpoint, and then promote it to default when it's ready. Agents that connect to the Toolbox consumer endpoint automatically receive the promoted default version without code changes. For details, see [Manage toolbox versions](../how-to/tools/toolbox.md#promote-a-version-to-default).
-
-Manage authentication for tools in a toolbox centrally. The toolbox handles credential injection, token refresh, and policy enforcement at runtime by using Microsoft Entra ID and OAuth, so consuming agents don't need to manage credentials for each tool individually. For authentication details, see [Set up MCP server authentication](../how-to/mcp-authentication.md).
-
-For setup steps, see [Create and use a Foundry Toolbox](../how-to/tools/toolbox.md).
 
 ## Use a tool in an agent
 

--- a/articles/foundry/agents/how-to/tools/agent-to-agent.md
+++ b/articles/foundry/agents/how-to/tools/agent-to-agent.md
@@ -25,6 +25,8 @@ zone_pivot_groups: selection-agent-to-agent
 
 You can extend the capabilities of your Microsoft Foundry agent by connecting to a remote Agent2Agent (A2A) endpoint that supports the [A2A protocol](https://a2a-protocol.org/latest/). The A2A tool enables agent-to-agent communication, making it easier to share context between Foundry-model-powered agents and external agent endpoints through a standardized protocol. This guide shows you how to configure a connection and call a remote A2A endpoint from your Foundry Agent Service agent.
 
+[!INCLUDE [toolbox-recommended](../../includes/toolbox-recommended.md)]
+
 > [!TIP]
 > This article covers how to **call** a remote A2A endpoint from your Foundry agent. If you want to **expose** your own agent as an A2A endpoint that other agents can call, see [Host an A2A-compatible agent endpoint](#host-an-a2a-compatible-agent-endpoint) later in this article.
 

--- a/articles/foundry/agents/how-to/tools/ai-search.md
+++ b/articles/foundry/agents/how-to/tools/ai-search.md
@@ -24,6 +24,8 @@ zone_pivot_groups: selection-ai-search-tool
 
 Ground your Foundry agent's responses in your proprietary content by connecting it to an Azure AI Search index. The [Azure AI Search](../../../../search/search-what-is-azure-search.md) tool retrieves indexed documents so the Foundry model powering the agent can generate answers with inline citations, enabling accurate, source-backed responses.
 
+[!INCLUDE [toolbox-recommended](../../includes/toolbox-recommended.md)]
+
 > [!IMPORTANT]
 > If you want to use a private virtual network with the Azure AI Search tool, make sure you use Microsoft Entra project managed identity to authenticate in your Azure AI Search connection. Key-based authentication isn't supported with private virtual networking.
 

--- a/articles/foundry/agents/how-to/tools/code-interpreter.md
+++ b/articles/foundry/agents/how-to/tools/code-interpreter.md
@@ -21,6 +21,8 @@ ai-usage: ai-assisted
 
 Code Interpreter enables a Microsoft Foundry agent to run Python code in a sandboxed execution environment. The agent's Foundry model writes and executes code for data analysis, chart generation, and iterative problem-solving tasks.
 
+[!INCLUDE [toolbox-recommended](../../includes/toolbox-recommended.md)]
+
 In this article, you create an agent that uses Code Interpreter, upload a CSV file for analysis, and download a generated chart.
 
 When you enable Code Interpreter, your agent can write and run Python code iteratively to solve data analysis and math tasks, and to generate charts.

--- a/articles/foundry/agents/how-to/tools/file-search.md
+++ b/articles/foundry/agents/how-to/tools/file-search.md
@@ -19,6 +19,8 @@ zone_pivot_groups: selection-file-search-upload-new
 # File search tool for agents
 Use the file search tool to enable Microsoft Foundry agents to search through your documents and retrieve relevant information. File search augments agents with knowledge from outside the Foundry model powering the agent, such as proprietary product information or user-provided documents.
 
+[!INCLUDE [toolbox-recommended](../../includes/toolbox-recommended.md)]
+
 In this article, you learn how to:
 
 - Upload files and create a vector store

--- a/articles/foundry/agents/how-to/tools/function-calling.md
+++ b/articles/foundry/agents/how-to/tools/function-calling.md
@@ -19,6 +19,8 @@ zone_pivot_groups: selection-function-calling-new
 # Use function calling with Microsoft Foundry agents
 Microsoft Foundry agents support function calling, which lets you extend agents with custom capabilities. Define a function with its name, parameters, and description, and the agent's Foundry model can request your app to call it. Your app executes the function and returns the output. The agent then uses the result to continue the conversation with accurate, real-time data from your systems.
 
+[!INCLUDE [toolbox-recommended](../../includes/toolbox-recommended.md)]
+
 > [!IMPORTANT]
 > Runs expire 10 minutes after creation. Submit your tool outputs before they expire.
 

--- a/articles/foundry/agents/how-to/tools/model-context-protocol.md
+++ b/articles/foundry/agents/how-to/tools/model-context-protocol.md
@@ -23,6 +23,8 @@ Connect your Foundry agents to [Model Context Protocol (MCP)](https://modelconte
 
 MCP is an open standard that defines how applications provide tools and contextual data to large language models (LLMs). It enables consistent, scalable integration of external tools into model workflows.
 
+[!INCLUDE [toolbox-recommended](../../includes/toolbox-recommended.md)]
+
 In this article, you learn how to:
 
 - Add a remote MCP server as a tool.

--- a/articles/foundry/agents/how-to/tools/openapi.md
+++ b/articles/foundry/agents/how-to/tools/openapi.md
@@ -21,6 +21,8 @@ Connect your Microsoft Foundry agents to external APIs using OpenAPI 3.0 and 3.1
 
 [OpenAPI specifications](https://spec.openapis.org/oas/latest.html) define a standard way to describe HTTP APIs so you can integrate existing services with your agents. Microsoft Foundry supports three authentication methods: `anonymous`, `API key`, and `managed identity`. For help choosing an authentication method, see [Choose an authentication method](#choose-an-authentication-method).
 
+[!INCLUDE [toolbox-recommended](../../includes/toolbox-recommended.md)]
+
 ### Usage support
 
 The following table shows SDK and setup support.

--- a/articles/foundry/agents/how-to/tools/web-search.md
+++ b/articles/foundry/agents/how-to/tools/web-search.md
@@ -25,6 +25,8 @@ zone_pivot_groups: selection-web-search
 
 The web search tool in Foundry Agent Service enables the agent's Foundry model to retrieve and ground responses with real-time information from the public web before generating output. When enabled, the model can return up-to-date answers with inline citations, helping you build agents that provide current, factual information to users.
 
+[!INCLUDE [toolbox-recommended](../../includes/toolbox-recommended.md)]
+
 > [!IMPORTANT]
 > - Web Search uses Grounding with Bing Search and Grounding with Bing Custom Search, which are [First Party Consumption Services](https://www.microsoft.com/licensing/terms/product/Glossary/EAEAS#:%7E:text=First-Party%20Consumption%20Services) governed by these [Grounding with Bing terms of use](https://www.microsoft.com/bing/apis/grounding-legal-enterprise) and the [Microsoft Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839&clcid=0x409).
 > - The Microsoft [Data Protection Addendum](https://aka.ms/dpa) doesn't apply to data sent to Grounding with Bing Search and Grounding with Bing Custom Search. When you use Grounding with Bing Search and Grounding with Bing Custom Search, data transfers occur outside compliance and geographic boundaries.

--- a/articles/foundry/agents/includes/toolbox-recommended.md
+++ b/articles/foundry/agents/includes/toolbox-recommended.md
@@ -1,0 +1,14 @@
+---
+title: include file
+description: include file
+author: mattwojo
+ms.author: mattwoj
+ms.service: microsoft-foundry
+ms.subservice: foundry-agent-service
+ms.topic: include
+ms.date: 07/16/2026
+ai-usage: ai-assisted
+---
+
+> [!TIP]
+> **Recommended: add this tool through a toolbox.** A [toolbox](/azure/foundry/agents/how-to/tools/toolbox) packages this tool and others behind a single managed MCP endpoint, so you configure the tool once and reuse it across agents and runtimes—with centralized credential injection, versioning, and policy enforcement, and no agent code changes when tools change. To attach this tool directly to a single agent instead, continue with this article. To get started with a toolbox, see the [toolbox quickstart](/azure/foundry/agents/quickstarts/quickstart-toolbox-agent).

--- a/articles/foundry/toc-files-foundry/tools-knowledge/toc.yml
+++ b/articles/foundry/toc-files-foundry/tools-knowledge/toc.yml
@@ -5,6 +5,20 @@ items:
 - name: Tool best practices
   href: ../../agents/concepts/tool-best-practice.md
 
+# Toolbox (recommended)
+- name: Toolbox (recommended)
+  items:
+  - name: What is a toolbox?
+    href: ../../agents/how-to/tools/toolbox.md
+  - name: Toolbox quickstart
+    href: ../../agents/quickstarts/quickstart-toolbox-agent.md
+  - name: Tool search (preview)
+    href: ../../agents/how-to/tools/tool-search.md
+  - name: Skills (preview)
+    href: ../../agents/how-to/tools/skills.md
+  - name: Create a private tool catalog
+    href: ../../agents/how-to/private-tool-catalog.md
+
 # Core tools
 - name: Core tools
   items:
@@ -96,18 +110,6 @@ items:
     href: ../../../ai-services/speech-service/voice-live-agents-quickstart.md
   - name: Enable voice for prompt agents
     href: ../../../ai-services/speech-service/how-to-voice-agent-integration.md
-
-# Toolbox and skills
-- name: Toolbox and skills
-  items:
-  - name: Toolbox
-    href: ../../agents/how-to/tools/toolbox.md
-  - name: Tool search (preview)
-    href: ../../agents/how-to/tools/tool-search.md
-  - name: Skills (preview)
-    href: ../../agents/how-to/tools/skills.md
-  - name: Create a private tool catalog
-    href: ../../agents/how-to/private-tool-catalog.md
 
 # Knowledge and retrieval
 - name: Knowledge and retrieval


### PR DESCRIPTION
﻿## Why

[Toolbox](https://learn.microsoft.com/azure/foundry/agents/how-to/tools/toolbox) is the recommended, GA way to package, govern, and version tools for Foundry agents behind a single managed MCP-compatible endpoint. Today the docs bury it: it sits ~7th in the tools TOC and is listed after built-in/custom tools in the overview, so readers discover per-tool wiring first and toolbox last.

This PR makes toolbox the recommended default across the tools happy path **without removing any direct-tool guidance** (recommend, don't replace).

## What changed

- **TOC** (`tools-knowledge/toc.yml`): promoted toolbox into a new top-level **Toolbox (recommended)** group right after Overview (What is a toolbox?, Toolbox quickstart, Tool search, Skills, Create a private tool catalog). Removed the old buried "Toolbox and skills" group.
- **Overview** (`concepts/tool-catalog.md`): added a "Recommended" tip and moved the **Toolbox** section to lead "Types of tools" (before Built-in and Custom), with a lead-in and quickstart link.
- **New shared include** (`agents/includes/toolbox-recommended.md`): a small "Recommended: add this tool through a toolbox" tip banner using site-absolute links (transclusion-safe).
- **8 tool how-to pages** now reference the include after their intro: function-calling, model-context-protocol, web-search, ai-search, code-interpreter, file-search, openapi, agent-to-agent.

## Impact

- No content removed; every direct-tool path still works.
- No headings renamed, so existing anchors/links are preserved.
