### PR TITLE
Update AI red teaming regions

### DIFF
--- a/articles/foundry/includes/concepts-evaluation-regions-limits-virtual-network-1.md
+++ b/articles/foundry/includes/concepts-evaluation-regions-limits-virtual-network-1.md
@@ -73,6 +73,9 @@ AI red teaming is supported in the following regions.
 
 - East US 2
 - North Central US
+- France Central
+- Sweden Central
+- Switzerland West
 
 ### Azure OpenAI graders regional availability
 


### PR DESCRIPTION
Added France Central, Sweden Central, and Switzerland West to the list of regions supporting AI red teaming.