### PR TITLE
Fix tenant ID header name in validation instructions

### DIFF
--- a/articles/foundry/agents/how-to/publish-copilot-virtual-network.md
+++ b/articles/foundry/agents/how-to/publish-copilot-virtual-network.md
@@ -295,7 +295,7 @@ However, if your network security requirements mean that traffic must be authent
 Validating the JWT is the strongest control, but it requires a component that can verify a signed token. If you don't have infrastructure that can validate a JWT, you can still reduce risk with two simpler checks at your inbound component:
 
 - **Restrict the source IP ranges** to the Teams Required ranges (see **Source IP ranges** in 5.1), so that only the Bot Channel Adapter can reach your entry point.
-- **Validate the caller's tenant ID.** The Bot Channel Adapter includes the caller's tenant ID in the `x-tenant-id` header. Reject any request whose tenant ID isn't your own.
+- **Validate the caller's tenant ID.** The Bot Channel Adapter includes the caller's tenant ID in the `x-ms-tenant-id` header. Reject any request whose tenant ID isn't your own.
 
 A published agent's Teams app can be installed in any tenant, so requests from outside your organization can reach your endpoint before Foundry applies RBAC. Checking the tenant ID lets you drop calls from tenants you don't intend to serve. This combination is weaker than JWT validation, because any caller that reaches your endpoint can set a header. Pair it with the source IP restriction so that only the Bot Channel Adapter can present the header. Together, the two checks give customers without JWT-capable infrastructure a meaningful layer of defense.
 


### PR DESCRIPTION
**Fix tenant ID header name in validation instructions**

This pull request corrects the HTTP header name for tenant ID validation in Step 5.3 of the "Publish agents to Microsoft 365 Copilot and Microsoft Teams by using the REST API" article.

**Change**

- Section 5.3 stated the Bot Channel Adapter sends the caller's tenant ID in the `x-tenant-id` header. The actual header is `x-ms-tenant-id`. Following the doc as written, a tenant-validation check would read an empty header and reject every request (or, if written to fail open, provide no protection at all).

**Evidence**

Verified via live inbound header capture on an M365 Copilot → Bot Channel Adapter → backend flow (app-identity / `SingleTenant` bot registration, matching the `msaAppType: 'SingleTenant'` config in Step 2 of this article):

- The inbound `POST` from the Channel Adapter carries `x-ms-tenant-id` (value = originating Entra tenant, consistent with the `serviceUrl` tenant segment), alongside `x-ms-conversation-id`.
- No `x-tenant-id` header is present on the request.
- The `x-ms-` prefix is consistent with the adapter's other headers (`x-ms-conversation-id`).

The header is emitted by Microsoft's Bot Channel Adapter, which is the same hop for both App Service–hosted and Foundry-hosted agents, so the corrected name applies to the Foundry VNet scenario described here.