### PR TITLE
fix(docs): updated matrix with right properties for transcribe

### DIFF
--- a/articles/ai-services/speech-service/includes/transcription-features.md
+++ b/articles/ai-services/speech-service/includes/transcription-features.md
@@ -21,8 +21,8 @@ This table shows transcription features that the fast transcription API supports
 | Profanity filtering | ✅                                | ✅                              | ✅                     |
 | Specify locale      | ✅                                | ✅                              | ✅                     |
 | Custom prompting    | ❌                                | ✅                              | ❌                     |
-| Phrase list         | ✅                                | ❌<sup>1</sup>                  | ❌                     |
+| Phrase list         | ✅                                | ❌<sup>1</sup>                  | ✅                     |
 | Segment-level timestamps         | ✅                                | ✅                 | ✅                     |
-| Word-level timestamps         | ✅                                | ✅                 | ❌                     |
+| Word-level timestamps         | ✅                                | ✅                 | ✅                     |
 
 <sup>1</sup>For LLM Speech, use prompting to guide the output style instead of using explicit phrase list.


### PR DESCRIPTION
Phrase list is specifically mentioned as a feature here:
https://learn.microsoft.com/en-us/azure/ai-services/speech-service/mai-transcribe?pivots=ai-foundry

And for word level highlights it was almost impossible to figure out whether it was supported from docs - i ended up manually calling the model with a test example and found _they do exist_.

Since my agents pulled down this source as a reason for why "this model does not support word-level highlights" i thought good to update it