### PR TITLE
Rewrite C# search tutorial for Azure Container Apps + managed identity

### DIFF
--- a/articles/search/tutorial-csharp-create-load-index.md
+++ b/articles/search/tutorial-csharp-create-load-index.md
@@ -5,7 +5,7 @@ ms.reviewer: diberry
 ms.service: azure-ai-search
 ms.update-cycle: 180-days
 ms.topic: tutorial
-ms.date: 07/21/2026
+ms.date: 07/24/2026
 ai-usage: ai-assisted
 ms.custom:
   - devx-track-csharp
@@ -20,30 +20,43 @@ ms.devlang: csharp
 
 [!INCLUDE [search-fiq-banner](./includes/search-fiq-banner.md)]
 
-Continue to build your search-enabled website by following these steps:
+Continue to build your search-enabled website for Azure Container Apps by following these steps:
 
-- Create a new index
-- Load data
+- Create a new index.
+- Load data.
 
 The program uses [Azure.Search.Documents](https://www.nuget.org/packages/Azure.Search.Documents/) in the Azure SDK for .NET:
 
-- [NuGet package Azure.Search.Documents](https://www.nuget.org/packages/Azure.Search.Documents/)
-- [Reference Documentation](/dotnet/api/overview/azure/search)
+- [NuGet package Azure.Search.Documents](https://www.nuget.org/packages/Azure.Search.Documents/).
+- [Reference documentation](/dotnet/api/overview/azure/search).
 
 Before you start, make sure you have room on your search service for a new index. The free tier limit is three indexes. The Basic tier limit is 15.
 
 ## Prepare the bulk import script for Search
 
-1. In Visual Studio Code, open the `Program.cs` file in the subdirectory, `azure-search-static-web-app/bulk-insert`, replace the following variables with your own values to authenticate with the Azure Search SDK.
+The bulk import project reads its configuration from environment variables. Managed identity is the default credential path. If `SEARCH_API_KEY` is empty, the code uses `DefaultAzureCredential` for Azure AI Search. Use an API key only as an explicit fallback.
 
-   - YOUR-SEARCH-SERVICE-NAME (not the full URL)
-   - YOUR-SEARCH-ADMIN-API-KEY (see [Find API keys](search-security-api-keys.md#find-existing-keys))
+1. In Visual Studio Code, open an integrated terminal for the `azure-search-static-web-app/bulk-insert` directory.
+
+1. Set the search service name. Replace `YOUR-SEARCH-SERVICE-NAME` with the name of your search service, not the full URL.
+
+    ```bash
+    export SEARCH_SERVICE_NAME="YOUR-SEARCH-SERVICE-NAME"
+    ```
+
+1. If you need key authentication, set `SEARCH_API_KEY` to an admin key for your search service. To find keys, see [Find API keys](search-security-api-keys.md#find-existing-keys).
+
+    ```bash
+    export SEARCH_API_KEY="YOUR-SEARCH-ADMIN-API-KEY"
+    ```
+
+    If you use managed identity or another credential supported by `DefaultAzureCredential`, omit `SEARCH_API_KEY`. Make sure your signed-in identity has access to create and load the search index.
+
+1. Review the current `Program.cs` configuration. It uses `SEARCH_SERVICE_NAME`, optional `SEARCH_API_KEY`, and `SEARCH_INDEX_NAME`, which defaults to `good-books`.
 
     :::code language="csharp" source="~/azure-search-static-web-app/bulk-insert/Program.cs" :::
 
-1. Open an integrated terminal in Visual Studio Code for the project directory's subdirectory, `azure-search-static-web-app/bulk-insert`.
-
-1. Run the following command to install the dependencies. 
+1. Run the following command to install the dependencies.
 
     ```bash
     dotnet restore
@@ -74,22 +87,22 @@ Once the upload completes, the search index is ready to use. Review your new ind
 
 1. Go to your search service in the [Azure portal](https://portal.azure.com).
 
-1. On the left, select **Search Management > Indexes**, and then select the good-books index.
+1. On the left, select **Search Management > Indexes**, and then select the `good-books` index.
 
     :::image type="content" source="media/tutorial-csharp-create-load-index/azure-portal-indexes-page.png" lightbox="media/tutorial-csharp-create-load-index/azure-portal-indexes-page.png" alt-text="Expandable screenshot of Azure portal showing the index." border="true":::
 
 1. By default, the index opens in the **Search Explorer** tab. Select **Search** to return documents from the index.
 
-    :::image type="content" source="media/tutorial-csharp-create-load-index/azure-portal-search-explorer.png" lightbox="media/tutorial-csharp-create-load-index/azure-portal-search-explorer.png" alt-text="Expandable screenshot of Azure portal showing search results" border="true":::
+    :::image type="content" source="media/tutorial-csharp-create-load-index/azure-portal-search-explorer.png" lightbox="media/tutorial-csharp-create-load-index/azure-portal-search-explorer.png" alt-text="Expandable screenshot of Azure portal showing search results." border="true":::
 
-## Rollback bulk import file changes
+## Clear local environment variables
 
-Use the following git command in the Visual Studio Code integrated terminal at the `bulk-insert` directory to roll back the changes to the `Program.cs` file. They aren't needed to continue the tutorial and you shouldn't save or push your API keys or search service name to your repo. 
+If you set `SEARCH_API_KEY` in your terminal, clear it after the import finishes. Don't save or commit API keys to your repository.
 
-```git
-git checkout .
+```bash
+unset SEARCH_API_KEY
 ```
 
 ## Next steps
 
-[Deploy your Static Web App](tutorial-csharp-deploy-static-web-app.md)
+[Deploy the app to Azure Container Apps](tutorial-csharp-deploy-static-web-app.md)

--- a/articles/search/tutorial-csharp-deploy-static-web-app.md
+++ b/articles/search/tutorial-csharp-deploy-static-web-app.md
@@ -1,11 +1,11 @@
 ---
-title: Deploy Search App (.NET Tutorial)
-description: Deploy search-enabled website with .NET APIs to Azure Static web app.
+title: Deploy a .NET search app to Azure Container Apps
+description: Deploy a search-enabled .NET website to Azure Container Apps with azd and managed identity.
 ms.reviewer: diberry
 ms.service: azure-ai-search
 ms.update-cycle: 180-days
 ms.topic: tutorial
-ms.date: 04/27/2026
+ms.date: 07/24/2026
 ms.custom:
   - devx-track-csharp
   - devx-track-dotnet
@@ -18,146 +18,105 @@ ai-usage: ai-assisted
 
 [!INCLUDE [search-fiq-banner](./includes/search-fiq-banner.md)]
 
-Deploy the search-enabled website as an Azure Static Web Apps site. This deployment includes both the React app for the web pages, and the Function app for search operations.  
+Deploy the search-enabled website to Azure Container Apps with the Azure Developer CLI (`azd`). This deployment includes the React client, the .NET API, Azure AI Search, managed identity, and supporting Azure resources.
 
-The static web app pulls the information and files for deployment from GitHub using your fork of the azure-search-static-web-app repository.  
+The deployment uses managed identity as the default authentication method for Azure AI Search. You can opt in to key authentication by setting `SEARCH_USE_KEY_AUTH` before deployment.
 
-## Create a Static Web App in Visual Studio Code
+## Sign in to Azure
 
-1. In Visual Studio Code, make sure you're at the repository root, and not the bulk-insert folder (for example, `azure-search-static-web-app`).
+1. In Visual Studio Code, open a terminal at the repository root, for example, `azure-search-static-web-app`.
 
-1. Select **Azure** from the Activity Bar, then open **Resources** from the side bar. 
+1. Sign in to Azure with `azd`.
 
-1. Right-click **Static Web Apps** and then select **Create Static Web App (Advanced)**. If you don't see this option, verify that you have the Azure Functions extension for Visual Studio Code.
-
-    :::image type="content" source="media/tutorial-csharp-static-web-app/visual-studio-code-create-static-web-app-resource-advanced.png" alt-text="Screenshot of Visual Studio Code, with the Azure Static Web Apps explorer showing the option to create an advanced static web app.":::
-
-1. If you see a pop-up window asking you to commit your changes, don't do this. The secrets from the bulk import step shouldn't be committed to the repository. 
-
-    To roll back the changes, in Visual Studio Code select the Source Control icon in the Activity bar, then select each changed file in the Changes list and select the **Discard changes** icon.
-
-1. Follow the prompts to create the static web app:
-
-    |Prompt|Enter|
-    |--|--|
-    |Select a resource group for new resources. | Create a new resource group for the static app.|
-    |Enter the name for the new Static Web App. | Give your static app a name, such as `my-demo-static-web-app`. |
-    |Select a SKU | Select the free SKU for this tutorial.|
-    |Select a location for new resources. | Choose a region near you. |
-    |Choose build preset to configure default project structure. |Select **Custom**. |
-    |Select the location of your client application code | `client`<br><br>This is the path, from the root of the repository, to your static web app. |
-    |Enter the path of your build output... | `build`<br><br>This is the path, from your static web app, to your generated files.|
-
-    If you get an error about an incorrect region, make sure the resource group and static web app resource are in one of the supported regions listed in the error response. 
-
-1. When the static web app is created, a GitHub workflow YML file is also created locally and on GitHub in your fork. This workflow executes in your fork, building and deploying the static web app and functions.
-
-   Check the status of static web app deployment using any of these approaches:
-
-   * Select **Open Actions in GitHub** from the Notifications. This opens a browser window pointed to your forked repo.
-   * Select the **Actions** tab in your forked repository. You should see a list of all workflows on your fork.
-   * Select the **Azure: Activity Log** in Visual Code. You should see a message similar to the following screenshot.
-
-     :::image type="content" source="media/tutorial-csharp-static-web-app/visual-studio-code-azure-activity-log.png" alt-text="Screenshot of the Activity Log in Visual Studio Code." border="true":::
-
-## Get the Azure AI Search query key in Visual Studio Code
-
-While you might be tempted to reuse your search admin key for query purposes that isn't following the principle of least privilege. The Azure Function should use the query key to conform to least privilege.
-
-1. In Visual Studio Code, open a new terminal window.
-
-1. Get the query API key with this Azure CLI command:
-
-    ```azurecli
-    az search query-key list --resource-group YOUR-SEARCH-SERVICE-RESOURCE-GROUP --service-name YOUR-SEARCH-SERVICE-NAME
+    ```bash
+    azd auth login
     ```
 
-1. Keep this query key to use in the next section. The query key authorizes read access to a search index. 
+1. If your browser prompts you, complete the sign-in flow with the Azure account you use for this tutorial.
 
-## Add environment variables in Azure portal
+## Configure the deployment environment
 
-The Azure Function app won't return search data until the search secrets are in settings. 
+1. Create an `azd` environment. Replace `YOUR-ENVIRONMENT-NAME` with a short name that identifies this tutorial deployment.
 
-1. Select **Azure** from the Activity Bar. 
+    ```bash
+    azd env new YOUR-ENVIRONMENT-NAME
+    ```
 
-1. Right-click on your Static Web Apps resource then select **Open in Portal**.
+1. Set key authentication only if your deployment requires API keys instead of managed identity.
 
-    :::image type="content" source="media/tutorial-csharp-static-web-app/open-static-web-app-in-azure-portal.png" alt-text="Screenshot of Visual Studio Code showing Azure Static Web Apps explorer with the Open in Portal option shown.":::
+    ```bash
+    azd env set SEARCH_USE_KEY_AUTH true
+    ```
 
-1. Select **Environment variables** then select **+ Add application setting**.
+    If you don't set `SEARCH_USE_KEY_AUTH`, the deployment uses managed identity. The Bicep infrastructure grants the container app identity access to the Azure AI Search data plane.
 
-    :::image type="content" source="media/tutorial-csharp-static-web-app/add-new-application-setting-to-static-web-app-in-portal.png" alt-text="Screenshot of the static web app's environment variables page in the Azure portal.":::
+## Deploy with azd up
 
-1. Add each of the following settings:
+1. From the repository root, run `azd up`.
 
-    |Setting|Your Search resource value|
-    |--|--|
-    |SearchApiKey|Your search query key|
-    |SearchServiceName|Your search resource name|
-    |SearchIndexName|`good-books`|
-    |SearchFacets|`authors*,language_code`|
+    ```bash
+    azd up
+    ```
 
-    Azure AI Search requires different syntax for filtering collections than it does for strings. Add a `*` after a field name to denote that the field is of type `Collection(Edm.String)`. This allows the Azure Function to add filters correctly to queries.
+1. When prompted, select the Azure subscription and location for the resources.
 
-1. Check your settings to make sure they look like the following screenshot.
+1. Wait for `azd` to provision the infrastructure, build the containers, push the images, and deploy the services to Azure Container Apps.
 
-    :::image type="content" source="media/tutorial-csharp-static-web-app/save-new-application-setting-to-static-web-app-in-portal.png" alt-text="Screenshot of browser showing Azure portal with the button to save the settings for your app.":::
+1. Review the output after deployment. The output includes the client and server fully qualified domain names (FQDNs) for the Azure Container Apps deployment.
 
-1. Return to Visual Studio Code. 
+    ```output
+    AZURE_CLIENT_URL: <client-container-app-fqdn>
+    AZURE_SERVER_URL: <server-container-app-fqdn>
+    SEARCH_SERVICE_NAME: <search-service-name>
+    ```
 
-1. Refresh your static web app to see the application settings and functions.
+    Use the `AZURE_CLIENT_URL` value to open the website. The client app calls the server app through the endpoint configured during deployment.
 
-    :::image type="content" source="media/tutorial-csharp-static-web-app/visual-studio-code-extension-fresh-resource-2.png" alt-text="Screenshot of Visual Studio Code showing the Azure Static Web Apps explorer with the new application settings." border="true":::
+## Use search in your Container Apps website
 
-If you don't see the application settings, revisit the steps for updating and relaunching the GitHub workflow.
+1. Open the client FQDN from the `azd up` output in a browser.
 
-## Use search in your static web app
+1. In the website search bar, enter a search query such as `code`, so the suggest feature suggests book titles.
 
-1. In Visual Studio Code, open the [Activity bar](https://code.visualstudio.com/docs/getstarted/userinterface), and select the Azure icon.
+1. Select a suggestion, or continue entering your own query. Press Enter when you finish your search query.
 
-1. In the Side bar, **right-click on your Azure subscription** under the `Static Web Apps` area and find the static web app you created for this tutorial.
-
-1. Right-click the static web app name and select **Browse site**.
-
-    :::image type="content" source="media/tutorial-csharp-static-web-app/visual-studio-code-browse-static-web-app.png" alt-text="Screenshot of Visual Studio Code showing the Azure Static Web Apps explorer showing the **Browse site** option.":::
-
-1. Select **Open** in the pop-up dialog.
-
-1. In the website search bar, enter a search query such as `code`, so the suggest feature suggests book titles. Select a suggestion or continue entering your own query. Press enter when you've completed your search query. 
-
-1. Review the results then select one of the books to see more details. 
+1. Review the results, and then select one of the books to see more details.
 
 ## Troubleshooting
 
-If the web app didn't deploy or work, use the following list to determine and fix the issue:
+If the web app didn't deploy or work, use the following list to determine and fix the issue.
 
-* **Did the deployment succeed?** 
+- **Did `azd up` complete?**
 
-    In order to determine if your deployment succeeded, you need to go to _your_ fork of the sample repo and review the success or failure of the GitHub action. There should be only one action and it should have static web app settings for the  `app_location`, `api_location`, and `output_location`. If the action didn't deploy successfully, dive into the action logs and look for the last failure. 
+  Review the `azd up` output for the first failed provisioning, build, or deploy step. If deployment stops during provisioning, check your subscription permissions and the selected region. If deployment stops during the container build or deploy steps, rerun `azd up` after you fix the reported issue.
 
-* **Does the client (front-end) application work?**
+- **Can you open the client endpoint?**
 
-    You should be able to get to your web app and it should successfully display. If the deployment succeeded but the website doesn't display, this might be an issue with how the static web app is configured for rebuilding the app, once it is on Azure. 
+  Open the `AZURE_CLIENT_URL` value from the `azd up` output. If the page doesn't load, go to the Azure portal, open the client container app, and review its revision status and logs.
 
-* **Does the API (serverless back-end) application work?**
+- **Can the client call the server endpoint?**
 
-    You should be able to interact with the client app, searching for books and filtering. If the form doesn't return any values, open the browser's developer tools, and determine if the HTTP calls to the API were successful. If the calls weren't successful, the most likely reason if the static web app configurations for the API endpoint name and search query key are incorrect.
+  Open your browser developer tools and review the network calls from the client app. If calls to the API fail, confirm that the server container app is running and that the client app received the server FQDN during deployment.
 
-    If the path to the Azure function code (`api_location`) isn't correct in the YML file, the application loads but won't call any of the functions that provide integration with Azure AI Search. Revisit the deployment section to make sure paths are correct.
+- **Can the server query Azure AI Search?**
+
+  If searches return errors, review the server container app logs. For managed identity, confirm that the identity has Azure AI Search data-plane access. For key authentication, confirm that you set `SEARCH_USE_KEY_AUTH` before deployment and that the generated container environment contains the search service configuration.
 
 ## Clean up resources
 
-To clean up the resources created in this tutorial, delete the resource group or individual resources.
+Use `azd down` to delete the Azure resources created by this tutorial.
 
-1. In Visual Studio Code, open the [Activity bar](https://code.visualstudio.com/docs/getstarted/userinterface), and select the Azure icon. 
+1. From the repository root, run the clean-up command.
 
-1. In the Side bar, **right-click on your Azure subscription** under the `Static Web Apps` area and find the app you created for this tutorial.
+    ```bash
+    azd down
+    ```
 
-1. Right-click the app name then select **Delete**.
+1. Review the resources that `azd` lists.
 
-1. If you no longer want the GitHub fork of the sample, remember to delete that on GitHub. Go to your fork's **Settings** then delete the repository.
+1. Confirm the deletion when prompted.
 
-1. To delete Azure AI Search, go to your search service in the [Azure portal](https://portal.azure.com) and select **Delete** at the top of the page.
+If you created an Azure AI Search service outside the `azd` deployment, go to your search service in the [Azure portal](https://portal.azure.com), and select **Delete** at the top of the page.
 
 ## Next steps
 

--- a/articles/search/tutorial-csharp-overview.md
+++ b/articles/search/tutorial-csharp-overview.md
@@ -1,11 +1,11 @@
 ---
-title: Add Search to Web Sites (.NET Tutorial)
-description: Technical overview and setup for adding search to a website and deploying to Azure Static Web App with .NET.
+title: Add search to web apps with .NET
+description: Add search to a .NET website and deploy it to Azure Container Apps with Azure Developer CLI and managed identity.
 ms.reviewer: diberry
 ms.service: azure-ai-search
 ms.update-cycle: 180-days
 ms.topic: tutorial
-ms.date: 04/27/2026
+ms.date: 07/24/2026
 ms.custom:
   - devx-track-csharp
   - devx-track-dotnet
@@ -14,72 +14,70 @@ ms.devlang: csharp
 ai-usage: ai-assisted
 ---
 
-# Step 1 - Overview of adding search to a static web app with .NET
+# Step 1 - Overview of adding search to a Container Apps web app with .NET
 
 [!INCLUDE [search-fiq-banner](./includes/search-fiq-banner.md)]
 
-This tutorial builds a website that searches through a catalog of books and then deploys the website to an Azure Static Web App. 
+This tutorial builds a website that searches through a catalog of books and deploys the website to Azure Container Apps. The deployment uses the Azure Developer CLI (`azd`) and managed identity as the default authentication method for Azure AI Search.
 
 ## What does the sample do?
 
-This sample website provides access to a catalog of 10,000 books. You can search the catalog by entering text in the search bar. While you enter text, the website uses the search index's suggestion feature to autocomplete the text. When the query finishes, the website displays the list of books with a portion of the details. You can select a book to see all the details, stored in the search index, of the book. 
+This sample website provides access to a catalog of 10,000 books. You can search the catalog by entering text in the search bar. While you enter text, the website uses the search index's suggestion feature to autocomplete the text.
+
+When the query finishes, the website displays the list of books with a portion of the details. You can select a book to see all the details, stored in the search index, for the book.
 
 :::image type="content" source="media/tutorial-csharp-overview/cognitive-search-enabled-book-website-2.png" alt-text="Screenshot of the sample app in a browser window.":::
 
 The search experience includes:
 
-- [Search](search-query-create.md) – provides search functionality for the application.
-- [Suggest](search-add-autocomplete-suggestions.md) – provides suggestions as the user is typing in the search bar.
-- [Facets and filters](search-faceted-navigation.md) - provides a faceted navigation structure that filters by author or language.
-- [Paginated results](search-pagination-page-layout.md) - provides paging controls for scrolling through results.
-- [Document Lookup](search-query-overview.md#document-look-up) – looks up a document by ID to retrieve all of its contents for the details page.
+- [Search](search-query-create.md) - Provides search functionality for the application.
+- [Suggest](search-add-autocomplete-suggestions.md) - Provides suggestions as the user types in the search bar.
+- [Facets and filters](search-faceted-navigation.md) - Provides a faceted navigation structure that filters by author or language.
+- [Paginated results](search-pagination-page-layout.md) - Provides paging controls for scrolling through results.
+- [Document lookup](search-query-overview.md#document-look-up) - Looks up a document by ID to retrieve all of its contents for the details page.
 
 ## How is the sample organized?
 
 The [sample code](https://github.com/Azure-Samples/azure-search-static-web-app) includes the following components:
 
-|App|Purpose|GitHub<br>Repository<br>Location|
+| App | Purpose | GitHub repository location |
 |--|--|--|
-|client|React app (presentation layer) to display books, with search. It calls the Azure Function app. |[/azure-search-static-web-app/client](https://github.com/Azure-Samples/azure-search-static-web-app/tree/main/client)|
-|api|Azure .NET Function app (business layer) - calls the Azure AI Search API using .NET SDK |[/azure-search-static-web-app/api](https://github.com/Azure-Samples/azure-search-static-web-app/tree/main/api)|
-|bulk insert|.NET project to create the index and add documents to it.|[/azure-search-static-web-app/bulk-insert](https://github.com/Azure-Samples/azure-search-static-web-app/tree/main/bulk-insert)|
+| `client` | React app (presentation layer) to display books with search. It calls the Azure Function app. | [/azure-search-static-web-app/client](https://github.com/Azure-Samples/azure-search-static-web-app/tree/main/client) |
+| `api` | Azure .NET Function app (business layer) that calls the Azure AI Search API with the .NET SDK. | [/azure-search-static-web-app/api](https://github.com/Azure-Samples/azure-search-static-web-app/tree/main/api) |
+| `bulk-insert` | .NET project to create the index and add documents to it. | [/azure-search-static-web-app/bulk-insert](https://github.com/Azure-Samples/azure-search-static-web-app/tree/main/bulk-insert) |
+| `infra` | Bicep infrastructure used by `azd` to deploy Azure AI Search, Azure Container Apps, and supporting resources. | [/azure-search-static-web-app/infra](https://github.com/Azure-Samples/azure-search-static-web-app/tree/main/infra) |
 
 ## Set up your development environment
 
-Create services and install the following software for your local development environment. 
+Create services and install the following software for your local development environment.
 
-- [Azure AI Search](search-create-service-portal.md), any region or tier
-- [.NET 9](https://dotnet.microsoft.com/download/dotnet) or latest version
-- [Git](https://git-scm.com/downloads)
-- [Visual Studio Code](https://code.visualstudio.com/)
-- [C# Dev Tools extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)
-- [Azure Static Web App extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps) 
+- [Azure AI Search](search-create-service-portal.md), any region or tier.
+- [.NET 9](https://dotnet.microsoft.com/download/dotnet) or later.
+- [Git](https://git-scm.com/downloads).
+- [Visual Studio Code](https://code.visualstudio.com/).
+- [C# Dev Tools extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit).
+- [Azure Developer CLI](/azure/developer/azure-developer-cli/install-azd) (`azd`).
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) or another Docker-compatible container runtime.
 
-This tutorial doesn't run the Azure Function API locally. If you want to run it locally, install [azure-functions-core-tools](/azure/azure-functions/functions-run-local?tabs=linux%2ccsharp%2cbash#install-the-azure-functions-core-tools).
+This tutorial doesn't run the Azure Function API locally. If you want to run it locally, install [Azure Functions Core Tools](/azure/azure-functions/functions-run-local?tabs=linux%2ccsharp%2cbash#install-the-azure-functions-core-tools).
 
-## Fork and clone the search sample with git
+## Clone the search sample with git
 
-To deploy the Static Web App, you need to fork the sample repository. The web apps use your GitHub fork location to decide the build actions and deployment content. Code execution in the Static Web App happens remotely, with Azure Static Web Apps reading the code from your forked sample.
+You can deploy the sample from a local clone. The `azd up` command reads the application and infrastructure files from your local repository, builds the containers, provisions Azure resources, and deploys the client and API to Azure Container Apps.
 
-1. On GitHub, fork the [azure-search-static-web-app repository](https://github.com/Azure-Samples/azure-search-static-web-app). 
-
-    Complete the [fork process](https://docs.github.com/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) in your web browser with your GitHub account. This tutorial uses your fork as part of the deployment to an Azure Static Web App. 
-
-1. At a Bash terminal, download your forked sample application to your local computer. 
-
-    Replace `YOUR-GITHUB-ALIAS` with your GitHub alias. 
+1. At a Bash terminal, clone the sample application to your local computer.
 
     ```bash
-    git clone https://github.com/YOUR-GITHUB-ALIAS/azure-search-static-web-app.git
+    git clone https://github.com/Azure-Samples/azure-search-static-web-app.git
     ```
 
-1. At the same Bash terminal, go into your forked repository for this website search example:
+1. At the same Bash terminal, go into the repository for this website search example:
 
     ```bash
     cd azure-search-static-web-app
     ```
 
-1. Use the Visual Studio Code command, `code .` to open your forked repository. You accomplish the remaining tasks from Visual Studio Code, unless specified.
+1. Use the Visual Studio Code command, `code .`, to open the repository. You accomplish the remaining tasks from Visual Studio Code, unless specified.
 
     ```bash
     code .
@@ -88,4 +86,4 @@ To deploy the Static Web App, you need to fork the sample repository. The web ap
 ## Next steps
 
 - [Create an index and load it with documents](tutorial-csharp-create-load-index.md)
-- [Deploy your Static Web App](tutorial-csharp-deploy-static-web-app.md)
+- [Deploy the app to Azure Container Apps](tutorial-csharp-deploy-static-web-app.md)

--- a/articles/search/tutorial-csharp-search-query-integration.md
+++ b/articles/search/tutorial-csharp-search-query-integration.md
@@ -5,7 +5,7 @@ ms.reviewer: diberry
 ms.service: azure-ai-search
 ms.update-cycle: 180-days
 ms.topic: tutorial
-ms.date: 04/27/2026
+ms.date: 07/24/2026
 ms.custom:
   - devx-track-csharp
   - devx-track-dotnet
@@ -18,26 +18,43 @@ ai-usage: ai-assisted
 
 [!INCLUDE [search-fiq-banner](./includes/search-fiq-banner.md)]
 
-In the previous lessons, you added search to a static web app. This lesson highlights the essential steps that establish integration. If you're looking for a cheat sheet on how to integrate search into your web app, this article explains what you need to know.
+In the previous lessons, you added search to a website that runs on Azure Container Apps. This lesson highlights the essential steps that establish integration. If you're looking for a cheat sheet on how to integrate search into your web app, this article explains what you need to know.
 
 ## Azure SDK Azure.Search.Documents
 
 The Function app uses the Azure SDK for Azure AI Search:
 
 * NuGet: [Azure.Search.Documents](https://www.nuget.org/packages/Azure.Search.Documents/)
-* Reference Documentation: [Client Library](/dotnet/api/overview/azure/search)
+* Reference documentation: [Client Library](/dotnet/api/overview/azure/search)
 
-The function app authenticates through the SDK to the cloud-based Azure AI Search API using your resource name, resource key, and index name. The secrets are stored in the static web app settings and pulled in to the function as environment variables. 
+The function app authenticates through the SDK to the cloud-based Azure AI Search API using the search service name and index name. In Azure Container Apps, the container environment provides the configuration values. Managed identity is the default credential path.
 
-## Configure secrets in a local.settings.json file
+## Managed identity authentication
+
+The deployed API uses `DefaultAzureCredential` in `Search.cs` when key authentication isn't explicitly enabled. In Azure Container Apps, `DefaultAzureCredential` uses the managed identity assigned to the container app to request tokens for Azure AI Search.
+
+The Bicep infrastructure assigns the managed identity access to the Azure AI Search data plane during `azd up`. This role assignment lets the API query the `good-books` index without storing a query key in the container environment.
+
+To use API keys instead, set `SEARCH_USE_KEY_AUTH` before deployment:
+
+```bash
+azd env set SEARCH_USE_KEY_AUTH true
+azd up
+```
+
+Use key authentication only when your environment requires it. Keep keys out of source control and rotate them according to your organization's security policy.
+
+## Configure local settings
+
+For local development, the sample `local.settings.json` file shows the values the function app expects. Use local settings for development only. In Azure Container Apps, deployment configuration provides the equivalent container environment values.
 
 :::code language="json" source="~/azure-search-static-web-app/api/sample.local.settings.json":::
 
 ## Azure Function: Search the catalog
 
-The [Search API](https://github.com/Azure-Samples/azure-search-static-web-app/blob/main/api/Search.cs) takes a search term and searches across the documents in the search index, returning a list of matches. Through the Suggest API, partial strings are sent to the search engine as the user types, suggesting search terms such as book titles and authors across the documents in the search index, and returning a small list of matches. 
+The [Search API](https://github.com/Azure-Samples/azure-search-static-web-app/blob/main/api/Search.cs) takes a search term and searches across the documents in the search index, returning a list of matches. Through the Suggest API, partial strings are sent to the search engine as the user types. The API suggests search terms such as book titles and authors across the documents in the search index, and returns a small list of matches.
 
-The Azure function pulls in the search configuration information, and fulfills the query. 
+The Azure function pulls in the search configuration information from the container environment, creates the Azure AI Search client, and fulfills the query.
 
 The search suggester, `sg`, is defined in the [schema file](https://github.com/Azure-Samples/azure-search-static-web-app/blob/main/bulk-insert/BookSearchIndex.cs) used during bulk upload.
 
@@ -45,23 +62,23 @@ The search suggester, `sg`, is defined in the [schema file](https://github.com/A
 
 ## Client: Search from the catalog
 
-Call the Azure Function in the React client at `\client\src\pages\Search\Search.jsx` with the following code to search for books. 
+Call the Azure Function in the React client at `\client\src\pages\Search\Search.jsx` with the following code to search for books.
 
 :::code language="csharp" source="~/azure-search-static-web-app/client/src/pages/Search/Search.jsx" :::
 
 ## Client: Suggestions from the catalog
 
-The Suggest function API is called in the React app at `\client\src\components\SearchBar\SearchBar.jsx` as part of the [Material UI's Autocomplete component](https://mui.com/material-ui/react-autocomplete/). This component uses the input text to search for authors and books that match the input text then displays those possible matches at selectable items in the drop-down list. 
+The Suggest function API is called in the React app at `\client\src\components\SearchBar\SearchBar.jsx` as part of the [Material UI Autocomplete component](https://mui.com/material-ui/react-autocomplete/). This component uses the input text to search for authors and books that match the input text. It then displays those possible matches as selectable items in the drop-down list.
 
 :::code language="csharp" source="~/azure-search-static-web-app/client/src/components/SearchBar/SearchBar.jsx" :::
 
-## Azure Function: Get specific document 
+## Azure Function: Get specific document
 
-The [Document Lookup API](https://github.com/Azure-Samples/azure-search-static-web-app/blob/main/api/Lookup.cs) takes an ID and returns the document object from the Search Index. 
+The [Document Lookup API](https://github.com/Azure-Samples/azure-search-static-web-app/blob/main/api/Lookup.cs) takes an ID and returns the document object from the search index.
 
 :::code language="csharp" source="~/azure-search-static-web-app/api/Lookup.cs"  :::
 
-## Client: Get specific document 
+## Client: Get specific document
 
 This function API is called in the React app at `\client\src\pages\Details\Details.jsx` as part of component initialization:
 


### PR DESCRIPTION
Rewrites the 4-page C# `Add search to web sites` tutorial for **Azure Container Apps + managed identity**, per ADO work item [596863](https://dev.azure.com/msft-skilling/Content/_workitems/edit/596863) and review with Hailey.

## Changes (all 4 tutorial pages)
- Static Web Apps -> **Azure Container Apps** (azd deploy)
- API keys -> **managed identity** (keyless) as the default
- Managed-identity code added to the `explore the code` page

## Pages
- `tutorial-csharp-overview.md`
- `tutorial-csharp-create-load-index.md`
- `tutorial-csharp-search-query-integration.md`
- `tutorial-csharp-deploy-static-web-app.md`

## Intended reviewers
- Hailey (all changes)
- Glenn Gailey (Azure Functions)
- Craig Shoemaker (ACA Bicep)

_Draft for review. Companion code work is tracked in the sample repo PR (managed-identity correctness for the AZD/ACA infra)._