### PR TITLE
Fix broken foundry-samples hosted-agent links after src/ restructuring

### DIFF
--- a/articles/foundry/agents/concepts/hosted-agent-contract.md
+++ b/articles/foundry/agents/concepts/hosted-agent-contract.md
@@ -96,7 +96,7 @@ This minimal handler forwards user input to a model from the Foundry model catal
 
 ### [Python](#tab/python)
 
-From [`bring-your-own/responses/hello-world/main.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/hello-world/main.py):
+From [`bring-your-own/responses/hello-world/main.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/main.py):
 
 ```python
 import asyncio

--- a/articles/foundry/agents/how-to/multiplex-session-users.md
+++ b/articles/foundry/agents/how-to/multiplex-session-users.md
@@ -38,7 +38,7 @@ A complete, runnable [session multiplexing sample](https://github.com/microsoft-
 
 Start with the core behavior: two users - call them Alice and Bob, the acted-for users in the sample - can share one `agent_session_id`, and the platform still keeps each user's conversation private. Your middle tier identifies the acted-for user on every call with the `x-ms-user-identity` header (delegation). To continue a user's own conversation, it passes that user's previous response as `previous_response_id`.
 
-The minimal [`invoke_previous_response_isolation.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/scripts/invoke_previous_response_isolation.py) caller in the sample sends exactly that, using the SDK's agent-bound Responses client:
+The minimal [`invoke_previous_response_isolation.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/scripts/invoke_previous_response_isolation.py) caller in the sample sends exactly that, using the SDK's agent-bound Responses client:
 
 ```python
 # Agent-bound Responses client from the Foundry SDK.
@@ -76,7 +76,7 @@ Decide how to map users to sessions. Common strategies include:
 - **Round-robin.** Distribute requests evenly across the pool. This strategy is simple, but a user's turns can land on different sessions.
 - **Group-based.** Route by tenant, team, or region so related users share sessions. This strategy is useful when users in a group share context.
 
-The [`invoke_session_pool.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/scripts/invoke_session_pool.py) caller in the sample implements caller-owned assignment with two strategies, `sticky-fill` and `round-robin`. A returning user always keeps their session; a new user is placed by the selected strategy. The sticky-fill path fills the least-loaded session and opens a new one only when every session is at capacity:
+The [`invoke_session_pool.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/scripts/invoke_session_pool.py) caller in the sample implements caller-owned assignment with two strategies, `sticky-fill` and `round-robin`. A returning user always keeps their session; a new user is placed by the selected strategy. The sticky-fill path fills the least-loaded session and opens a new one only when every session is at capacity:
 
 ```python
 def get_session_for_user(self, user_id: str) -> str:
@@ -104,7 +104,7 @@ Feed the returned session ID into the same delegated call shown earlier: it beco
 
 ## Handle the request in your container
 
-On protocol 2.0.0, the platform resolves the acted-for user and exposes it to your handler through `get_request_context()`. Validate that context (fail closed when it's missing, such as on local runs), then let the platform return the per-user history with `context.get_history()`. The [`main.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/main.py) handler in the sample keeps no conversation state of its own:
+On protocol 2.0.0, the platform resolves the acted-for user and exposes it to your handler through `get_request_context()`. Validate that context (fail closed when it's missing, such as on local runs), then let the platform return the per-user history with `context.get_history()`. The [`main.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/main.py) handler in the sample keeps no conversation state of its own:
 
 ```python
 from azure.ai.agentserver.core import get_request_context
@@ -180,7 +180,7 @@ For a worked example of per-session storage to build on, see the [note-taking ag
 
 ## Verify isolation
 
-Confirm the guarantee with the sample's A-A-B test, [`invoke_previous_response_isolation.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/scripts/invoke_previous_response_isolation.py). Run it against your deployed agent with two distinct users (the sample defaults to Alice and Bob):
+Confirm the guarantee with the sample's A-A-B test, [`invoke_previous_response_isolation.py`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/scripts/invoke_previous_response_isolation.py). Run it against your deployed agent with two distinct users (the sample defaults to Alice and Bob):
 
 1. As Alice, create a response in a shared session and capture its `id`.
 1. As Alice, create a second response in the same session with `previous_response_id` set to the first response's `id`, and capture its `id`.

--- a/articles/foundry/agents/quickstarts/quickstart-toolbox-agent.md
+++ b/articles/foundry/agents/quickstarts/quickstart-toolbox-agent.md
@@ -59,7 +59,7 @@ azd env set FOUNDRY_PROJECT_ENDPOINT "$(azd env get-value FOUNDRY_PROJECT_ENDPOI
 
 :::zone pivot="azd"
 
-The sample includes a [`toolbox.yaml`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/toolbox.yaml) in `src/toolbox-agent` that defines both tools behind one endpoint. Create the toolbox from that file:
+The sample includes a [`toolbox.yaml`](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/src/agent-framework-agent-with-foundry-toolbox-responses/toolbox.yaml) in `src/toolbox-agent` that defines both tools behind one endpoint. Create the toolbox from that file:
 
 ```bash
 azd ai toolbox create my-toolbox --from-file ./src/toolbox-agent/toolbox.yaml


### PR DESCRIPTION
## Summary
Sample folders in the `microsoft-foundry/foundry-samples` repo were restructured so each sample's contents now live under `src/<sample-name>/`. This broke several deep links in the hosted-agent docs. This PR updates them to the new paths (verified against the live repo, all now return HTTP 200).

## Fixed links
- **multiplex-session-users.md** (4 links): `session-multiplexing/{scripts,main.py}` -> `session-multiplexing/src/hello-world-session-multiplexing-python-responses/...`
- **hosted-agent-contract.md** (1 link): `hello-world/main.py` -> `hello-world/src/hello-world-python-responses/main.py`
- **quickstart-toolbox-agent.md** (1 link): `04-foundry-toolbox/toolbox.yaml` -> `04-foundry-toolbox/src/agent-framework-agent-with-foundry-toolbox-responses/toolbox.yaml`

All other hosted-agents sample links were verified and remain valid.