### PR TITLE
Remove duplicate Claude versions description in models-partners.md

### DIFF
--- a/articles/foundry/foundry-models/includes/models-partners.md
+++ b/articles/foundry/foundry-models/includes/models-partners.md
@@ -46,7 +46,6 @@ Anthropic's flagship product is Claude, a frontier AI model trusted by leading e
 
 > [!NOTE]
 > [!INCLUDE [claude-versions-description](claude-versions-description.md)] 
-> [!INCLUDE [claude-versions-description](claude-versions-description.md)] 
 
 #### Subscription type and region support
 


### PR DESCRIPTION
This pull request makes a minor update to the `models-partners.md` documentation by removing a duplicate inclusion of the Claude versions description. This helps keep the documentation concise and avoids redundant information.