### PR TITLE
Add quickstart for deploying hosted agents from private registries

### DIFF
--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -22,6 +22,10 @@ credentials.
 The pattern works with any registry that supports OIDC token exchange. The
 examples use JFrog Artifactory and Docker Distribution.
 
+The Entra application provides the audience value used during token exchange.
+The Foundry project managed identity authenticates with the registry's OIDC
+provider, which exchanges its token for short-lived image-pull credentials.
+
 ## Prerequisites
 
 - An Azure subscription.

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -202,10 +202,7 @@ azd deploy
 #### Verify the agent is active
 
 ```azurecli
-az foundry hosted-agent show \
-  --agent-name "<agent-name>" \
-  --project "<foundry-project-name>" \
-  --resource-group "<resource-group>"
+azd ai agent show
 ```
 
 Wait for the status to change to **Active**.
@@ -213,10 +210,7 @@ Wait for the status to change to **Active**.
 #### Invoke the agent
 
 ```azurecli
-az foundry hosted-agent invoke \
-  --agent-name "<agent-name>" \
-  --project "<foundry-project-name>" \
-  --resource-group "<resource-group>"
+azd ai agent invoke "<prompt>"
 ```
 
 ### [With VNet isolation](#tab/with-vnet)
@@ -248,10 +242,7 @@ VNet's private network path.
 #### Verify the agent is active
 
 ```azurecli
-az foundry hosted-agent show \
-  --agent-name "<agent-name>" \
-  --project "<foundry-project-name>" \
-  --resource-group "<resource-group>"
+azd ai agent show
 ```
 
 Wait for the status to change to **Active**.
@@ -259,10 +250,7 @@ Wait for the status to change to **Active**.
 #### Invoke the agent
 
 ```azurecli
-az foundry hosted-agent invoke \
-  --agent-name "<agent-name>" \
-  --project "<foundry-project-name>" \
-  --resource-group "<resource-group>"
+azd ai agent invoke "<prompt>"
 ```
 
 ## Troubleshooting

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -1,5 +1,5 @@
 ---
-title: "Private registry connections for hosted agents"
+title: "Bring your own registry for hosted agents"
 description: "Deploy a Microsoft Foundry hosted agent from your private container registry using OIDC-based authentication."
 author: aahill
 ms.author: aahi
@@ -12,7 +12,7 @@ ms.custom: mode-other, dev-focus, doc-kit-assisted
 ai-usage: ai-assisted
 ---
 
-# Private registry connections for hosted agents
+# Bring your own registry for hosted agents
 
 Deploy a Microsoft Foundry hosted agent from a private container registry by
 using OIDC-based authentication. This approach uses short-lived tokens instead

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -14,6 +14,8 @@ ai-usage: ai-assisted
 
 # Bring your own registry for hosted agents
 
+**Overview**
+
 This article shows how to let a Microsoft Foundry hosted agent pull its image
 from a private container registry. You create a Foundry project connection that
 uses OIDC token exchange and short-lived tokens instead of stored registry

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -94,12 +94,16 @@ Create the connection with these values:
 | `metadata.type` | `registry_connection` |
 | `metadata.mode` | `oauth_token_exchange` |
 
-## Create the agent
+## Create the registry connection
 
-Create the connection with `azd ai connection create` or the Azure REST API.
-Use the values from the registry tab you selected.
+If your Foundry project already exists, create the registry connection with
+Azure Developer CLI or the Azure REST API. If the project doesn't exist, use
+the Azure REST API to create the project and registry connection before you
+create the agent. Use the values from the registry tab you selected.
 
 ### [Azure Developer CLI](#tab/azd)
+
+Use this option when you already have a Foundry project.
 
 ```bash
 azd extension install azure.ai.connections
@@ -117,17 +121,10 @@ azd ai connection create private-registry \
   --metadata "mode=oauth_token_exchange"
 ```
 
-Initialize the agent with the existing project and connection:
-
-```bash
-azd ai agent init --no-prompt \
-  --agent-name private-registry-agent \
-  --image <registry-host>/<repository>/agent:<tag> \
-  --project-id <foundry-project-resource-id> \
-  --registry-connection private-registry
-```
-
 ### [Azure REST API](#tab/rest)
+
+Use this option for an existing project, or to create the project and registry
+connection before you create the agent.
 
 Check whether the connection exists before creating it. Reuse an existing
 connection with the expected configuration.
@@ -169,9 +166,21 @@ az rest `
   --body $connection
 ```
 
-## Configure your agent
+## Create the agent
 
-In your `azure.yaml`, reference the private registry image and connection:
+After the registry connection exists, initialize the agent with the existing
+project and connection:
+
+```bash
+azd ai agent init --no-prompt \
+  --agent-name private-registry-agent \
+  --image <registry-host>/<repository>/agent:<tag> \
+  --project-id <foundry-project-resource-id> \
+  --registry-connection private-registry
+```
+
+In the generated `azure.yaml`, reference the private registry image and
+connection:
 
 ```yaml
 services:

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -14,106 +14,105 @@ ai-usage: ai-assisted
 
 # Private registry connections for hosted agents
 
-Deploy a Microsoft Foundry hosted agent from your private container registry using OIDC-based authentication. This approach uses short-lived tokens instead of storing long-lived credentials in your Foundry configuration.
+Deploy a Microsoft Foundry hosted agent from a private container registry by
+using OIDC-based authentication. This approach uses short-lived tokens instead
+of storing registry credentials in your Foundry configuration.
 
-This article uses JFrog Artifactory as an example. The same steps work for any registry that supports OIDC token exchange.
+The examples use JFrog Artifactory and Docker Distribution. The same
+connection pattern works with any registry that supports OIDC token exchange.
 
 ## Prerequisites
 
 - An Azure subscription.
-- A Foundry project with `Foundry Project Manager` role. See [Hosted agent permissions reference](../concepts/hosted-agent-permissions.md).
+- A Foundry project with `Foundry Project Manager` role. See [Hosted agent permissions reference](hosted-agent-permissions.md).
 - [Azure CLI](/cli/azure/install-azure-cli) installed and authenticated.
-- A private container registry with OIDC support (for example, JFrog Artifactory).
+- A private container registry with OIDC support.
 - A container image in your registry.
 - Permissions to configure OIDC in your registry.
+- For Docker Distribution, an RFC 8693 token-exchange service and a registry
+  token service.
 
 ## Set up OIDC authentication
 
-### Step 1: Create a Microsoft Entra workload identity
+### Step 1: Create an Entra application
 
 ```azurecli
-# Create an app registration
 az ad app create --display-name "Foundry-Registry-Agent"
 ```
 
-Copy the `appId` output.
+Copy the application (client) ID. Use it as the audience when you configure
+your registry.
 
-```azurecli
-# Create a service principal
-az ad sp create --id <appId>
+## Configure the registry connection
 
-# Create a federated credential for OIDC token exchange
-az ad app federated-credential create \
-  --id <appId> \
-  --parameters '{
-    "name": "foundry-registry",
-    "issuer": "https://token.actions.githubusercontent.com",
-    "subject": "repo:foundry-project-<projectId>:ref:refs/heads/main",
-    "audiences": ["api://AzureADTokenExchange"]
-  }'
-```
+Choose the registry that hosts your image. In either tab:
 
-### Step 2: Configure your registry for OIDC
+1. Configure the registry to trust the Foundry project managed identity.
+2. Map the identity to a repository with image-pull permission.
+3. Create the Foundry project connection with `type` set to
+   `registry_connection` and `mode` set to `oauth_token_exchange`.
 
-#### JFrog Artifactory
+### [JFrog Artifactory](#tab/jfrog)
 
-1. In JFrog, go to **Administration** > **Integrations** > **OIDC**.
-2. Create an OIDC provider:
-   - **Issuer URL**: The Foundry issuer (provided by your Foundry project)
-   - **Audience**: `api://AzureADTokenExchange`
-   - **Service Account**: Create a service account with read access to your image repository
-3. Note the token endpoint: `https://<your-jfrog-instance>/artifactory/api/oauth/token`
+1. In JFrog, create an OIDC provider for the Foundry project managed identity.
+2. Give the provider read access to the image repository.
+3. Use `/access/api/v1/oidc/token` as the token endpoint.
+4. Record the JFrog OIDC provider name.
 
-#### Other registries
+Create the connection with these values:
 
-Configure your registry to:
-- Trust the Foundry OIDC issuer
-- Map OIDC subjects to a registry identity with image pull permissions
-- Expose a token endpoint that exchanges OIDC tokens for registry tokens
+| Field | Value |
+| --- | --- |
+| `target` | `https://<jfrog-host>` |
+| `credentials.keys.audience` | Entra application client ID |
+| `credentials.keys.tokenEndpoint` | `/access/api/v1/oidc/token` |
+| `credentials.keys.body.provider_name` | JFrog OIDC provider name |
 
-### Step 3: Test token exchange
+When you create the connection, also provide
+`body.provider_name=<oidc-provider-name>` as a custom key.
 
-```bash
-# Get an OIDC token
-OIDC_TOKEN=$(az account get-access-token \
-  --resource "api://AzureADTokenExchange" \
-  --output json | jq -r '.accessToken')
+### [Docker Distribution](#tab/docker-distribution)
 
-# Exchange for a registry token
-curl -X POST https://<your-jfrog-instance>/artifactory/api/oauth/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
-  -d "subject_token=$OIDC_TOKEN" \
-  -d "subject_token_type=urn:ietf:params:oauth:token-type:access_token"
-```
+Docker Distribution doesn't provide OIDC by itself. Deploy an RFC 8693
+token-exchange service and a registry token service in front of the registry.
 
-A successful response includes an `access_token`.
+1. Configure the token-exchange service to validate the Foundry project
+   managed identity token.
+2. Configure the registry token service to authorize the exchanged credential
+   for the image repository.
+3. Return a short-lived `access_token` and `username` from the
+   token-exchange service.
+4. Record the token-exchange endpoint.
 
-## Deploy your agent
+Create the connection with these values:
 
-## Step 1: Create a registry connection
+| Field | Value |
+| --- | --- |
+| `target` | `https://<registry-host>` |
+| `credentials.keys.audience` | Entra application client ID |
+| `credentials.keys.tokenEndpoint` | `<token-exchange-path>` |
+| `metadata.type` | `registry_connection` |
+| `metadata.mode` | `oauth_token_exchange` |
 
-You can create the registry connection using either approach:
+## Create the agent
+
+Create the connection with `azd ai connection create` or the Azure REST API.
+Use the values from the registry tab you selected.
 
 ### [Azure Developer CLI](#tab/azd)
-
-Install the `azure.ai.connections` extension and create the connection in your
-existing Foundry project:
 
 ```bash
 azd extension install azure.ai.connections
 
-PROJECT_ID="<foundry-project-resource-id>"
 PROJECT_ENDPOINT="https://<account>.services.ai.azure.com/api/projects/<project>"
 
 azd ai connection create private-registry \
   --project-endpoint "$PROJECT_ENDPOINT" \
   --kind custom-keys \
-  --target "https://<private-registry-host>" \
+  --target "https://<registry-host>" \
   --auth-type custom-keys \
-  --custom-key "audience=<entra-audience-app-id>" \
-  --custom-key "tokenEndpoint=/access/api/v1/oidc/token" \
-  --custom-key "body.provider_name=<oidc-provider-name>" \
+  --custom-key "audience=<entra-application-client-id>" \
+  --custom-key "tokenEndpoint=<token-exchange-path>" \
   --metadata "type=registry_connection" \
   --metadata "mode=oauth_token_exchange"
 ```
@@ -123,14 +122,15 @@ Initialize the agent with the existing project and connection:
 ```bash
 azd ai agent init --no-prompt \
   --agent-name private-registry-agent \
-  --image <private-registry-host>/<repository>/agent:<tag> \
-  --project-id "$PROJECT_ID" \
+  --image <registry-host>/<repository>/agent:<tag> \
+  --project-id <foundry-project-resource-id> \
   --registry-connection private-registry
 ```
 
 ### [Azure REST API](#tab/rest)
 
-First check whether the connection already exists:
+Check whether the connection exists before creating it. Reuse an existing
+connection with the expected configuration.
 
 ```powershell
 $connectionId = "/subscriptions/$env:AZURE_SUBSCRIPTION_ID/resourceGroups/$env:AZURE_RESOURCE_GROUP/providers/Microsoft.CognitiveServices/accounts/$env:FOUNDRY_ACCOUNT_NAME/projects/$env:FOUNDRY_PROJECT_NAME/connections/$env:FOUNDRY_CONNECTION_NAME"
@@ -140,16 +140,14 @@ az rest `
   --url "https://management.azure.com${connectionId}?api-version=2025-10-01-preview"
 ```
 
-If it exists and has the expected configuration, reuse it. Do not recreate or overwrite it.
-
-If it does not exist, create it:
+If the connection doesn't exist, create it with the registry-specific values:
 
 ```powershell
 $connection = @{
   properties = @{
     category = "CustomKeys"
     authType = "CustomKeys"
-    target = "https://$($env:JFROG_HOST)"
+    target = "https://<registry-host>"
     isSharedToAll = $true
     useWorkspaceManagedIdentity = $false
     metadata = @{
@@ -158,9 +156,8 @@ $connection = @{
     }
     credentials = @{
       keys = @{
-        audience = $env:OIDC_AUDIENCE
-        tokenEndpoint = "/access/api/v1/oidc/token"
-        "body.provider_name" = $env:JFROG_OIDC_PROVIDER
+        audience = "<entra-application-client-id>"
+        tokenEndpoint = "<token-exchange-path>"
       }
     }
   }
@@ -172,18 +169,7 @@ az rest `
   --body $connection
 ```
 
-**Important fields:**
-
-| Field | Value |
-|-------|-------|
-| `metadata.type` | `registry_connection` |
-| `metadata.mode` | `oauth_token_exchange` |
-| `target` | JFrog HTTPS origin |
-| `credentials.keys.audience` | Entra application client ID |
-| `credentials.keys.tokenEndpoint` | `/access/api/v1/oidc/token` |
-| `credentials.keys.body.provider_name` | JFrog OIDC provider name |
-
-## Step 2: Update your agent configuration
+## Configure your agent
 
 In your `azure.yaml`, reference the private registry image and connection:
 
@@ -191,7 +177,7 @@ In your `azure.yaml`, reference the private registry image and connection:
 services:
   private-registry-agent:
     host: azure.ai.agent
-    image: "docker.artifactory.jfrog.io/your-repo/your-agent:latest"
+    image: "<registry-host>/<repository>/agent:<tag>"
     docker:
       imagePassthrough: true
     registryConnectionId: "private-registry"
@@ -239,16 +225,16 @@ For Foundry projects deployed within a VNet with private endpoints:
 
 #### Network requirements
 
-Before deployment, ensure that your JFrog token endpoint is accessible from
+Before deployment, ensure that your registry token endpoint is accessible from
 within the Foundry VNet.
 
-#### JFrog connectivity via Private Link
+#### Registry connectivity via Private Link
 
-If your JFrog instance supports Azure Private Link:
+If your registry supports Azure Private Link:
 
-1. Create a private endpoint in your Foundry VNet targeting the JFrog service.
+1. Create a private endpoint in your Foundry VNet targeting your registry.
 2. Configure DNS resolution in your Foundry VNet to route requests to your
-   JFrog instance through the private endpoint.
+   registry through the private endpoint.
 
 #### Deploy the agent
 
@@ -285,11 +271,11 @@ az foundry hosted-agent invoke \
 |-------|-------|-----------|
 | Token exchange fails with "Public access is disabled" | Registry OIDC provider isn't accessible publicly | Verify your registry OIDC integration allows public token requests |
 | Token exchange fails with "invalid_subject" or "invalid_audience" | OIDC claim mappings don't match | Confirm issuer, subject, and audience values match in Entra ID and your registry |
-| Image pull fails after successful token exchange | Service account lacks permissions | Ensure the registry service account has read access to your image repository |
+| Image pull fails after successful token exchange | Registry identity lacks permissions | Ensure the registry identity has read access to your image repository |
 | Agent deployment fails with connection timeout | VNet isolation blocks registry access | Set up a private link to allow access to the registry token endpoint |
 
 ## Next steps
 
-- Learn more about [hosted agent concepts](../concepts/hosted-agents.md).
-- Explore [Foundry permissions](../concepts/hosted-agent-permissions.md).
-- Set up [CI/CD for agents](set-up-cicd-hosted-agent.md).
+- Learn more about [hosted agent concepts](hosted-agents.md).
+- Explore [Foundry permissions](hosted-agent-permissions.md).
+- Set up [CI/CD for agents](../quickstarts/set-up-cicd-hosted-agent.md).

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -21,14 +21,15 @@ from a private container registry. You create a Foundry project connection that
 uses OIDC token exchange and short-lived tokens instead of stored registry
 credentials.
 
-The pattern works with any registry that supports OIDC token exchange. For a
-walkthrough, see the setup examples for JFrog Artifactory and Docker
-Distribution.
+The pattern works with any registry that supports OIDC token exchange.
 
 The Entra application provides the audience value used during token exchange.
 The Foundry project managed identity (MI) authenticates with the registry's
 OIDC provider, which exchanges its token for short-lived image-pull
 credentials.
+
+For a walkthrough, see the setup examples for JFrog Artifactory and Docker
+Distribution.
 
 ## Prerequisites
 

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -21,8 +21,9 @@ from a private container registry. You create a Foundry project connection that
 uses OIDC token exchange and short-lived tokens instead of stored registry
 credentials.
 
-The pattern works with any registry that supports OIDC token exchange. The
-examples use JFrog Artifactory and Docker Distribution.
+The pattern works with any registry that supports OIDC token exchange. For a
+walkthrough, see the setup examples for JFrog Artifactory and Docker
+Distribution.
 
 The Entra application provides the audience value used during token exchange.
 The Foundry project managed identity (MI) authenticates with the registry's

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -21,12 +21,10 @@ from a private container registry. You create a Foundry project connection that
 uses OIDC token exchange and short-lived tokens instead of stored registry
 credentials.
 
-The pattern works with any registry that supports OIDC token exchange.
-
-The Entra application provides the audience value used during token exchange.
-The Foundry project managed identity (MI) authenticates with the registry's
-OIDC provider, which exchanges its token for short-lived image-pull
-credentials.
+The pattern works with any registry that supports OIDC token exchange. The
+Entra application provides the audience value used during token exchange. The
+Foundry project managed identity (MI) authenticates with the registry's OIDC
+provider, which exchanges its token for short-lived image-pull credentials.
 
 For a walkthrough, see the setup examples for JFrog Artifactory and Docker
 Distribution.

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -91,7 +91,7 @@ A successful response includes an `access_token`.
 
 ## Deploy your agent
 
-### Step 1: Create a registry connection
+## Step 1: Create a registry connection
 
 You can create the registry connection using either approach:
 
@@ -183,7 +183,7 @@ az rest `
 | `credentials.keys.tokenEndpoint` | `/access/api/v1/oidc/token` |
 | `credentials.keys.body.provider_name` | JFrog OIDC provider name |
 
-### Step 2: Update your agent configuration
+## Step 2: Update your agent configuration
 
 In your `azure.yaml`, reference the private registry image and connection:
 
@@ -198,6 +198,8 @@ services:
     kind: hosted
     name: private-registry-agent
 ```
+
+## Network options
 
 Choose the option that matches your Foundry project network configuration:
 

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -23,8 +23,9 @@ The pattern works with any registry that supports OIDC token exchange. The
 examples use JFrog Artifactory and Docker Distribution.
 
 The Entra application provides the audience value used during token exchange.
-The Foundry project managed identity authenticates with the registry's OIDC
-provider, which exchanges its token for short-lived image-pull credentials.
+The Foundry project managed identity (MI) authenticates with the registry's
+OIDC provider, which exchanges its token for short-lived image-pull
+credentials.
 
 ## Prerequisites
 

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -95,9 +95,7 @@ A successful response includes an `access_token`.
 
 You can create the registry connection using either approach:
 
-### [Azure Developer CLI](#tab/registry-azd)
-
-:::zone pivot="registry-azd"
+### [Azure Developer CLI](#tab/azd)
 
 Install the `azure.ai.connections` extension and create the connection in your
 existing Foundry project:
@@ -130,11 +128,7 @@ azd ai agent init --no-prompt \
   --registry-connection private-registry
 ```
 
-:::zone-end
-
-### [Azure REST API](#tab/registry-rest)
-
-:::zone pivot="registry-rest"
+### [Azure REST API](#tab/rest)
 
 First check whether the connection already exists:
 
@@ -189,8 +183,6 @@ az rest `
 | `credentials.keys.tokenEndpoint` | `/access/api/v1/oidc/token` |
 | `credentials.keys.body.provider_name` | JFrog OIDC provider name |
 
-:::zone-end
-
 ### Step 2: Update your agent configuration
 
 In your `azure.yaml`, reference the private registry image and connection:
@@ -212,8 +204,6 @@ Choose the option that matches your Foundry project network configuration:
 ### [Without VNet isolation](#tab/without-vnet)
 
 For Foundry projects with public network access:
-
-:::zone pivot="without-vnet"
 
 #### Deploy the agent
 
@@ -241,13 +231,9 @@ az foundry hosted-agent invoke \
   --resource-group "<resource-group>"
 ```
 
-:::zone-end
-
 ### [With VNet isolation](#tab/with-vnet)
 
 For Foundry projects deployed within a VNet with private endpoints:
-
-:::zone pivot="with-vnet"
 
 #### Network requirements
 
@@ -290,8 +276,6 @@ az foundry hosted-agent invoke \
   --project "<foundry-project-name>" \
   --resource-group "<resource-group>"
 ```
-
-:::zone-end
 
 ## Troubleshooting
 

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -1,22 +1,22 @@
 ---
-title: "Quickstart: Deploy a hosted agent from a private registry"
+title: "Private registry connections for hosted agents"
 description: "Deploy a Microsoft Foundry hosted agent from your private container registry using OIDC-based authentication."
 author: aahill
 ms.author: aahi
 ms.date: 08/18/2026
 ms.manager: mcleans
-ms.topic: quickstart
+ms.topic: concept-article
 ms.service: microsoft-foundry
 ms.subservice: foundry-agent-service
 ms.custom: mode-other, dev-focus, doc-kit-assisted
 ai-usage: ai-assisted
 ---
 
-# Quickstart: Deploy a hosted agent from a private registry
+# Private registry connections for hosted agents
 
 Deploy a Microsoft Foundry hosted agent from your private container registry using OIDC-based authentication. This approach uses short-lived tokens instead of storing long-lived credentials in your Foundry configuration.
 
-This quickstart uses JFrog Artifactory as an example. The same steps work for any registry that supports OIDC token exchange.
+This article uses JFrog Artifactory as an example. The same steps work for any registry that supports OIDC token exchange.
 
 ## Prerequisites
 

--- a/articles/foundry/agents/concepts/private-registry-connections.md
+++ b/articles/foundry/agents/concepts/private-registry-connections.md
@@ -14,12 +14,13 @@ ai-usage: ai-assisted
 
 # Bring your own registry for hosted agents
 
-Deploy a Microsoft Foundry hosted agent from a private container registry by
-using OIDC-based authentication. This approach uses short-lived tokens instead
-of storing registry credentials in your Foundry configuration.
+This article shows how to let a Microsoft Foundry hosted agent pull its image
+from a private container registry. You create a Foundry project connection that
+uses OIDC token exchange and short-lived tokens instead of stored registry
+credentials.
 
-The examples use JFrog Artifactory and Docker Distribution. The same
-connection pattern works with any registry that supports OIDC token exchange.
+The pattern works with any registry that supports OIDC token exchange. The
+examples use JFrog Artifactory and Docker Distribution.
 
 ## Prerequisites
 

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -1,0 +1,159 @@
+---
+title: "Quickstart: Deploy a hosted agent from a private registry"
+description: "Deploy a Microsoft Foundry hosted agent from your private container registry using OIDC-based authentication."
+author: aahill
+ms.author: aahi
+ms.date: 08/18/2026
+ms.manager: mcleans
+ms.topic: quickstart
+ms.service: microsoft-foundry
+ms.subservice: foundry-agent-service
+ms.custom: mode-other, dev-focus, doc-kit-assisted
+ai-usage: ai-assisted
+---
+
+# Quickstart: Deploy a hosted agent from a private registry
+
+Deploy a Microsoft Foundry hosted agent from your private container registry using OIDC-based authentication. This approach uses short-lived tokens instead of storing long-lived credentials in your Foundry configuration.
+
+This quickstart uses JFrog Artifactory as an example. The same steps work for any registry that supports OIDC token exchange.
+
+## Prerequisites
+
+- An Azure subscription.
+- A Foundry project with `Foundry Project Manager` role. See [Hosted agent permissions reference](../concepts/hosted-agent-permissions.md).
+- [Azure CLI](/cli/azure/install-azure-cli) installed and authenticated.
+- A private container registry with OIDC support (for example, JFrog Artifactory).
+- A container image in your registry.
+- Permissions to configure OIDC in your registry.
+
+## Set up OIDC authentication
+
+### Step 1: Create a Microsoft Entra workload identity
+
+```azurecli
+# Create an app registration
+az ad app create --display-name "Foundry-Registry-Agent"
+```
+
+Copy the `appId` output.
+
+```azurecli
+# Create a service principal
+az ad sp create --id <appId>
+
+# Create a federated credential for OIDC token exchange
+az ad app federated-credential create \
+  --id <appId> \
+  --parameters '{
+    "name": "foundry-registry",
+    "issuer": "https://token.actions.githubusercontent.com",
+    "subject": "repo:foundry-project-<projectId>:ref:refs/heads/main",
+    "audiences": ["api://AzureADTokenExchange"]
+  }'
+```
+
+### Step 2: Configure your registry for OIDC
+
+#### JFrog Artifactory
+
+1. In JFrog, go to **Administration** > **Integrations** > **OIDC**.
+2. Create an OIDC provider:
+   - **Issuer URL**: The Foundry issuer (provided by your Foundry project)
+   - **Audience**: `api://AzureADTokenExchange`
+   - **Service Account**: Create a service account with read access to your image repository
+3. Note the token endpoint: `https://<your-jfrog-instance>/artifactory/api/oauth/token`
+
+#### Other registries
+
+Configure your registry to:
+- Trust the Foundry OIDC issuer
+- Map OIDC subjects to a registry identity with image pull permissions
+- Expose a token endpoint that exchanges OIDC tokens for registry tokens
+
+### Step 3: Test token exchange
+
+```bash
+# Get an OIDC token
+OIDC_TOKEN=$(az account get-access-token \
+  --resource "api://AzureADTokenExchange" \
+  --output json | jq -r '.accessToken')
+
+# Exchange for a registry token
+curl -X POST https://<your-jfrog-instance>/artifactory/api/oauth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  -d "subject_token=$OIDC_TOKEN" \
+  -d "subject_token_type=urn:ietf:params:oauth:token-type:access_token"
+```
+
+A successful response includes an `access_token`.
+
+## Deploy your agent
+
+### Step 1: Create a registry connection
+
+```azurecli
+az foundry registry create \
+  --name "my-registry" \
+  --registry-type "oidc" \
+  --registry-url "https://<your-jfrog-instance>/artifactory/docker" \
+  --token-endpoint "https://<your-jfrog-instance>/artifactory/api/oauth/token" \
+  --project "<foundry-project-name>" \
+  --resource-group "<resource-group>"
+```
+
+Copy the registry ID from the output.
+
+### Step 2: Update your agent configuration
+
+In your `azure.yaml`, reference the private registry image and connection:
+
+```yaml
+agent:
+  image:
+    name: "docker.artifactory.jfrog.io/your-repo/your-agent:latest"
+    registry: "<registry-connection-id>"
+```
+
+### Step 3: Deploy
+
+```azurecli
+azd deploy
+```
+
+### Step 4: Verify the agent is active
+
+```azurecli
+az foundry hosted-agent show \
+  --agent-name "<agent-name>" \
+  --project "<foundry-project-name>" \
+  --resource-group "<resource-group>"
+```
+
+Wait for the status to change to **Active**.
+
+### Step 5: Invoke the agent
+
+```azurecli
+az foundry hosted-agent invoke \
+  --agent-name "<agent-name>" \
+  --project "<foundry-project-name>" \
+  --resource-group "<resource-group>"
+```
+
+## Troubleshooting
+
+| Issue | Cause | Resolution |
+|-------|-------|-----------|
+| Token exchange fails with "Public access is disabled" | Registry OIDC provider isn't accessible publicly | Verify your registry OIDC integration allows public token requests |
+| Token exchange fails with "invalid_subject" or "invalid_audience" | OIDC claim mappings don't match | Confirm issuer, subject, and audience values match in Entra ID and your registry |
+| Image pull fails after successful token exchange | Service account lacks permissions | Ensure the registry service account has read access to your image repository |
+| Agent deployment fails with connection timeout | VNet isolation blocks registry access | Set up a private link or firewall rule to allow outbound traffic to the registry token endpoint |
+
+## Next steps
+
+- Learn more about [hosted agent concepts](../concepts/hosted-agents.md).
+- Explore [Foundry permissions](../concepts/hosted-agent-permissions.md).
+- Set up [CI/CD for agents](set-up-cicd-hosted-agent.md).
+

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -116,13 +116,17 @@ agent:
     registry: "<registry-connection-id>"
 ```
 
-### Step 3: Deploy
+## Scenario A: Foundry without VNet isolation
+
+For Foundry projects with public network access (no VNet injection):
+
+### Deploy the agent
 
 ```azurecli
 azd deploy
 ```
 
-### Step 4: Verify the agent is active
+### Verify the agent is active
 
 ```azurecli
 az foundry hosted-agent show \
@@ -133,7 +137,63 @@ az foundry hosted-agent show \
 
 Wait for the status to change to **Active**.
 
-### Step 5: Invoke the agent
+### Invoke the agent
+
+```azurecli
+az foundry hosted-agent invoke \
+  --agent-name "<agent-name>" \
+  --project "<foundry-project-name>" \
+  --resource-group "<resource-group>"
+```
+
+## Scenario B: Foundry with VNet isolation
+
+For Foundry projects deployed within a VNet with private endpoints:
+
+### Network requirements
+
+Before deployment, ensure:
+- Your JFrog token endpoint is accessible from within the Foundry VNet.
+- Set up a private link or private endpoint to your JFrog instance (if needed).
+- Configure firewall rules to allow outbound traffic from your Foundry VNet to the JFrog token endpoint.
+
+### JFrog connectivity options
+
+**Option 1: Private Link (recommended)**
+
+If your JFrog instance supports Azure Private Link:
+
+1. Create a private endpoint in your Foundry VNet targeting the JFrog service.
+2. Configure DNS resolution in your Foundry VNet to route requests to your JFrog instance via the private endpoint.
+
+**Option 2: Firewall rules**
+
+If Private Link isn't available:
+
+1. Identify the JFrog token endpoint URL (for example, `https://<your-jfrog-instance>/artifactory/api/oauth/token`).
+2. Add a firewall rule to allow outbound HTTPS (port 443) from your Foundry VNet to the JFrog instance.
+3. Ensure DNS resolution works from within your Foundry VNet.
+
+### Deploy the agent
+
+```azurecli
+azd deploy
+```
+
+Foundry automatically uses the registry connection to pull images over the VNet's private network path.
+
+### Verify the agent is active
+
+```azurecli
+az foundry hosted-agent show \
+  --agent-name "<agent-name>" \
+  --project "<foundry-project-name>" \
+  --resource-group "<resource-group>"
+```
+
+Wait for the status to change to **Active**.
+
+### Invoke the agent
 
 ```azurecli
 az foundry hosted-agent invoke \

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -157,22 +157,12 @@ Before deployment, ensure:
 - Set up a private link or private endpoint to your JFrog instance (if needed).
 - Configure firewall rules to allow outbound traffic from your Foundry VNet to the JFrog token endpoint.
 
-### JFrog connectivity options
-
-**Option 1: Private Link (recommended)**
+### JFrog connectivity via Private Link
 
 If your JFrog instance supports Azure Private Link:
 
 1. Create a private endpoint in your Foundry VNet targeting the JFrog service.
 2. Configure DNS resolution in your Foundry VNet to route requests to your JFrog instance via the private endpoint.
-
-**Option 2: Firewall rules**
-
-If Private Link isn't available:
-
-1. Identify the JFrog token endpoint URL (for example, `https://<your-jfrog-instance>/artifactory/api/oauth/token`).
-2. Add a firewall rule to allow outbound HTTPS (port 443) from your Foundry VNet to the JFrog instance.
-3. Ensure DNS resolution works from within your Foundry VNet.
 
 ### Deploy the agent
 

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -93,6 +93,10 @@ A successful response includes an `access_token`.
 
 ### Step 1: Create a registry connection
 
+You can create the registry connection using either approach:
+
+#### Option A: Azure CLI command
+
 ```azurecli
 az foundry registry create \
   --name "my-registry" \
@@ -104,6 +108,61 @@ az foundry registry create \
 ```
 
 Copy the registry ID from the output.
+
+#### Option B: Azure REST API
+
+First check whether the connection already exists:
+
+```powershell
+$connectionId = "/subscriptions/$env:AZURE_SUBSCRIPTION_ID/resourceGroups/$env:AZURE_RESOURCE_GROUP/providers/Microsoft.CognitiveServices/accounts/$env:FOUNDRY_ACCOUNT_NAME/projects/$env:FOUNDRY_PROJECT_NAME/connections/$env:FOUNDRY_CONNECTION_NAME"
+
+az rest `
+  --method get `
+  --url "https://management.azure.com${connectionId}?api-version=2025-10-01-preview"
+```
+
+If it exists and has the expected configuration, reuse it. Do not recreate or overwrite it.
+
+If it does not exist, create it:
+
+```powershell
+$connection = @{
+  properties = @{
+    category = "CustomKeys"
+    authType = "CustomKeys"
+    target = "https://$($env:JFROG_HOST)"
+    isSharedToAll = $true
+    useWorkspaceManagedIdentity = $false
+    metadata = @{
+      type = "registry_connection"
+      mode = "oauth_token_exchange"
+    }
+    credentials = @{
+      keys = @{
+        audience = $env:OIDC_AUDIENCE
+        tokenEndpoint = "/access/api/v1/oidc/token"
+        "body.provider_name" = $env:JFROG_OIDC_PROVIDER
+      }
+    }
+  }
+} | ConvertTo-Json -Depth 10
+
+az rest `
+  --method put `
+  --url "https://management.azure.com${connectionId}?api-version=2025-10-01-preview" `
+  --body $connection
+```
+
+**Important fields:**
+
+| Field | Value |
+|-------|-------|
+| `metadata.type` | `registry_connection` |
+| `metadata.mode` | `oauth_token_exchange` |
+| `target` | JFrog HTTPS origin |
+| `credentials.keys.audience` | Entra application client ID |
+| `credentials.keys.tokenEndpoint` | `/access/api/v1/oidc/token` |
+| `credentials.keys.body.provider_name` | JFrog OIDC provider name |
 
 ### Step 2: Update your agent configuration
 

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -95,7 +95,9 @@ A successful response includes an `access_token`.
 
 You can create the registry connection using either approach:
 
-#### Option A: azd
+### [Azure Developer CLI](#tab/registry-azd)
+
+:::zone pivot="registry-azd"
 
 Install the `azure.ai.connections` extension and create the connection in your
 existing Foundry project:
@@ -128,7 +130,11 @@ azd ai agent init --no-prompt \
   --registry-connection private-registry
 ```
 
-#### Option B: Azure REST API
+:::zone-end
+
+### [Azure REST API](#tab/registry-rest)
+
+:::zone pivot="registry-rest"
 
 First check whether the connection already exists:
 
@@ -182,6 +188,8 @@ az rest `
 | `credentials.keys.audience` | Entra application client ID |
 | `credentials.keys.tokenEndpoint` | `/access/api/v1/oidc/token` |
 | `credentials.keys.body.provider_name` | JFrog OIDC provider name |
+
+:::zone-end
 
 ### Step 2: Update your agent configuration
 

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -1,8 +1,8 @@
 ---
 title: "Quickstart: Deploy a hosted agent from a private registry"
 description: "Deploy a Microsoft Foundry hosted agent from your private container registry using OIDC-based authentication."
-author: harsheetshah
-ms.author: harsheetshah
+author: aahill
+ms.author: aahi
 ms.date: 08/18/2026
 ms.manager: mcleans
 ms.topic: quickstart

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -1,8 +1,8 @@
 ---
 title: "Quickstart: Deploy a hosted agent from a private registry"
 description: "Deploy a Microsoft Foundry hosted agent from your private container registry using OIDC-based authentication."
-author: aahill
-ms.author: aahi
+author: harsheetshah
+ms.author: harsheetshah
 ms.date: 08/18/2026
 ms.manager: mcleans
 ms.topic: quickstart

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -95,19 +95,38 @@ A successful response includes an `access_token`.
 
 You can create the registry connection using either approach:
 
-#### Option A: Azure CLI command
+#### Option A: azd
 
-```azurecli
-az foundry registry create \
-  --name "my-registry" \
-  --registry-type "oidc" \
-  --registry-url "https://<your-jfrog-instance>/artifactory/docker" \
-  --token-endpoint "https://<your-jfrog-instance>/artifactory/api/oauth/token" \
-  --project "<foundry-project-name>" \
-  --resource-group "<resource-group>"
+Install the `azure.ai.connections` extension and create the connection in your
+existing Foundry project:
+
+```bash
+azd extension install azure.ai.connections
+
+PROJECT_ID="<foundry-project-resource-id>"
+PROJECT_ENDPOINT="https://<account>.services.ai.azure.com/api/projects/<project>"
+
+azd ai connection create private-registry \
+  --project-endpoint "$PROJECT_ENDPOINT" \
+  --kind custom-keys \
+  --target "https://<private-registry-host>" \
+  --auth-type custom-keys \
+  --custom-key "audience=<entra-audience-app-id>" \
+  --custom-key "tokenEndpoint=/access/api/v1/oidc/token" \
+  --custom-key "body.provider_name=<oidc-provider-name>" \
+  --metadata "type=registry_connection" \
+  --metadata "mode=oauth_token_exchange"
 ```
 
-Copy the registry ID from the output.
+Initialize the agent with the existing project and connection:
+
+```bash
+azd ai agent init --no-prompt \
+  --agent-name private-registry-agent \
+  --image <private-registry-host>/<repository>/agent:<tag> \
+  --project-id "$PROJECT_ID" \
+  --registry-connection private-registry
+```
 
 #### Option B: Azure REST API
 
@@ -169,10 +188,15 @@ az rest `
 In your `azure.yaml`, reference the private registry image and connection:
 
 ```yaml
-agent:
-  image:
-    name: "docker.artifactory.jfrog.io/your-repo/your-agent:latest"
-    registry_connection_id: "<registry-connection-id>"
+services:
+  private-registry-agent:
+    host: azure.ai.agent
+    image: "docker.artifactory.jfrog.io/your-repo/your-agent:latest"
+    docker:
+      imagePassthrough: true
+    registryConnectionId: "private-registry"
+    kind: hosted
+    name: private-registry-agent
 ```
 
 ## Scenario A: Foundry without VNet isolation
@@ -265,4 +289,3 @@ az foundry hosted-agent invoke \
 - Learn more about [hosted agent concepts](../concepts/hosted-agents.md).
 - Explore [Foundry permissions](../concepts/hosted-agent-permissions.md).
 - Set up [CI/CD for agents](set-up-cicd-hosted-agent.md).
-

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -113,7 +113,7 @@ In your `azure.yaml`, reference the private registry image and connection:
 agent:
   image:
     name: "docker.artifactory.jfrog.io/your-repo/your-agent:latest"
-    registry: "<registry-connection-id>"
+    registry_connection_id: "<registry-connection-id>"
 ```
 
 ## Scenario A: Foundry without VNet isolation

--- a/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
+++ b/articles/foundry/agents/quickstarts/quickstart-bring-your-own-registry.md
@@ -199,17 +199,21 @@ services:
     name: private-registry-agent
 ```
 
-## Scenario A: Foundry without VNet isolation
+Choose the option that matches your Foundry project network configuration:
 
-For Foundry projects with public network access (no VNet injection):
+### [Without VNet isolation](#tab/without-vnet)
 
-### Deploy the agent
+For Foundry projects with public network access:
+
+:::zone pivot="without-vnet"
+
+#### Deploy the agent
 
 ```azurecli
 azd deploy
 ```
 
-### Verify the agent is active
+#### Verify the agent is active
 
 ```azurecli
 az foundry hosted-agent show \
@@ -220,7 +224,7 @@ az foundry hosted-agent show \
 
 Wait for the status to change to **Active**.
 
-### Invoke the agent
+#### Invoke the agent
 
 ```azurecli
 az foundry hosted-agent invoke \
@@ -229,33 +233,37 @@ az foundry hosted-agent invoke \
   --resource-group "<resource-group>"
 ```
 
-## Scenario B: Foundry with VNet isolation
+:::zone-end
+
+### [With VNet isolation](#tab/with-vnet)
 
 For Foundry projects deployed within a VNet with private endpoints:
 
-### Network requirements
+:::zone pivot="with-vnet"
 
-Before deployment, ensure:
-- Your JFrog token endpoint is accessible from within the Foundry VNet.
-- Set up a private link or private endpoint to your JFrog instance (if needed).
-- Configure firewall rules to allow outbound traffic from your Foundry VNet to the JFrog token endpoint.
+#### Network requirements
 
-### JFrog connectivity via Private Link
+Before deployment, ensure that your JFrog token endpoint is accessible from
+within the Foundry VNet.
+
+#### JFrog connectivity via Private Link
 
 If your JFrog instance supports Azure Private Link:
 
 1. Create a private endpoint in your Foundry VNet targeting the JFrog service.
-2. Configure DNS resolution in your Foundry VNet to route requests to your JFrog instance via the private endpoint.
+2. Configure DNS resolution in your Foundry VNet to route requests to your
+   JFrog instance through the private endpoint.
 
-### Deploy the agent
+#### Deploy the agent
 
 ```azurecli
 azd deploy
 ```
 
-Foundry automatically uses the registry connection to pull images over the VNet's private network path.
+Foundry automatically uses the registry connection to pull images over the
+VNet's private network path.
 
-### Verify the agent is active
+#### Verify the agent is active
 
 ```azurecli
 az foundry hosted-agent show \
@@ -266,7 +274,7 @@ az foundry hosted-agent show \
 
 Wait for the status to change to **Active**.
 
-### Invoke the agent
+#### Invoke the agent
 
 ```azurecli
 az foundry hosted-agent invoke \
@@ -274,6 +282,8 @@ az foundry hosted-agent invoke \
   --project "<foundry-project-name>" \
   --resource-group "<resource-group>"
 ```
+
+:::zone-end
 
 ## Troubleshooting
 
@@ -282,7 +292,7 @@ az foundry hosted-agent invoke \
 | Token exchange fails with "Public access is disabled" | Registry OIDC provider isn't accessible publicly | Verify your registry OIDC integration allows public token requests |
 | Token exchange fails with "invalid_subject" or "invalid_audience" | OIDC claim mappings don't match | Confirm issuer, subject, and audience values match in Entra ID and your registry |
 | Image pull fails after successful token exchange | Service account lacks permissions | Ensure the registry service account has read access to your image repository |
-| Agent deployment fails with connection timeout | VNet isolation blocks registry access | Set up a private link or firewall rule to allow outbound traffic to the registry token endpoint |
+| Agent deployment fails with connection timeout | VNet isolation blocks registry access | Set up a private link to allow access to the registry token endpoint |
 
 ## Next steps
 

--- a/articles/foundry/toc-files-foundry/agent-service/toc.yml
+++ b/articles/foundry/toc-files-foundry/agent-service/toc.yml
@@ -88,6 +88,8 @@ items:
       href: ../../agents/how-to/tools/browser-automation-hosted-agent-quickstart.md
     - name: Add persistent memory
       href: ../../agents/quickstarts/quickstart-memory-hosted-agent.md
+    - name: Deploy from a private registry
+      href: ../../agents/quickstarts/quickstart-bring-your-own-registry.md
     - name: Evaluate an agent
       href: ../../observability/quickstarts/quickstart-evaluate-hosted-agent.md
     - name: Optimize a hosted agent

--- a/articles/foundry/toc-files-foundry/agent-service/toc.yml
+++ b/articles/foundry/toc-files-foundry/agent-service/toc.yml
@@ -76,6 +76,8 @@ items:
       href: ../../agents/concepts/runtime-components.md
     - name: Runtime contract
       href: ../../agents/concepts/hosted-agent-contract.md
+    - name: Private registry connections
+      href: ../../agents/concepts/private-registry-connections.md
   - name: Quickstarts
     items:
     - name: Deploy your first agent
@@ -88,8 +90,6 @@ items:
       href: ../../agents/how-to/tools/browser-automation-hosted-agent-quickstart.md
     - name: Add persistent memory
       href: ../../agents/quickstarts/quickstart-memory-hosted-agent.md
-    - name: Deploy from a private registry
-      href: ../../agents/quickstarts/quickstart-bring-your-own-registry.md
     - name: Evaluate an agent
       href: ../../observability/quickstarts/quickstart-evaluate-hosted-agent.md
     - name: Optimize a hosted agent


### PR DESCRIPTION
- New quickstart: Deploy a hosted agent from a private registry with OIDC
- Covers any registry supporting OIDC (JFrog Artifactory example)
- Includes registry connection setup, OIDC configuration, and deployment steps
- Added troubleshooting table for common issues
- Updated TOC with new quickstart entry in Hosted agents section