### PR TITLE
docs(foundry): remove duplicate environment variables block in TypeScript tab

### DIFF
--- a/articles/foundry/includes/quickstart-v2-get-code.md
+++ b/articles/foundry/includes/quickstart-v2-get-code.md
@@ -57,13 +57,6 @@ Follow along below or get the code:
 
 Sign in using the CLI `az login` command to authenticate before running your TypeScript scripts.
 
-Store [your project endpoint](../tutorials/quickstart-create-foundry-resources.md#get-your-project-connection-details) as an environment variable. Also set these values for use in your scripts.
-
-```
-PROJECT_ENDPOINT=<endpoint copied from welcome screen>
-AGENT_NAME="MyAgent"
-```
-
 # [Java](#tab/java)
 
 Store [your project endpoint](../tutorials/quickstart-create-foundry-resources.md#get-your-project-connection-details) as an environment variable. Also set these values for use in your scripts.


### PR DESCRIPTION
## Summary
Removes a duplicate copy-pasted environment variables code block (`PROJECT_ENDPOINT` and `AGENT_NAME`) from the bottom of the TypeScript tab in `quickstart-v2-get-code.md`.

## Changes
- Removed the redundant second environment variables paragraph and snippet under `# [TypeScript](#tab/typescript)`. The structure now matches the other language tabs (Python, C#, Java).

## Screenshot
<img width="1140" height="867" alt="image" src="https://github.com/user-attachments/assets/eeac88f7-14ca-47b9-85e3-942495ab663b" />
