### PR TITLE
docs: link compaction to context provider guidance

### DIFF
--- a/agent-framework/concepts/agents/conversations/compaction.md
+++ b/agent-framework/concepts/agents/conversations/compaction.md
@@ -7,6 +7,7 @@ ms.topic: article
 ms.author: edvan
 ms.date: 07/30/2026
 ms.service: agent-framework
+ai-usage: ai-assisted
 ---
 
 <!--
@@ -772,3 +773,7 @@ Harness Agent isn't currently available in the Go SDK. Register a compaction con
 
 > [!div class="nextstepaction"]
 > [Middleware](../middleware/index.md)
+
+### Go deeper
+
+- [Context providers](context-providers.md)


### PR DESCRIPTION
## Summary

- Link the compaction article to the Context Providers deep dive.
- Add the required AI-assistance disclosure.

Fixes microsoft/agent-framework#4629

## Validation

- Verified the relative documentation link.
- Ran `git diff --check`.