### PR TITLE
Update policy name for disabling local authentication

### DIFF
--- a/articles/ai-services/disable-local-auth.md
+++ b/articles/ai-services/disable-local-auth.md
@@ -19,7 +19,7 @@ Foundry Tools provides Microsoft Entra authentication support for all resources.
 
 ## How to disable local authentication
 
-You can disable local authentication using the Azure policy **Foundry Tools resources should have key access disabled (disable local authentication)**. Set it at the subscription level or resource group level to enforce the policy for a group of services.
+You can disable local authentication using the Azure policy **Azure AI Services resources should have key access disabled (disable local authentication)**. Set it at the subscription level or resource group level to enforce the policy for a group of services.
 
 If you're creating an account using Bicep / ARM template, you can set the property `disableLocalAuth` to `true` to disable local authentication. For more information, see 
 [Microsoft.CognitiveServices accounts - Bicep, ARM template, & Terraform](/azure/templates/microsoft.cognitiveservices/accounts)


### PR DESCRIPTION
The current documentation refers to an Azure Built-in policy that does not exist: `Foundry Tools resources should have key access disabled (disable local authentication)`. I have corrected it to `Azure AI Services resources should have key access disabled (disable local authentication)`, ID: `71ef260a-8f18-47b7-abcb-62d0673d94dc`