### PR TITLE
Fix retirement date for gpt-image-1.5

### DIFF
--- a/articles/foundry/openai/includes/concepts-model-retirement-schedule-content.md
+++ b/articles/foundry/openai/includes/concepts-model-retirement-schedule-content.md
@@ -75,7 +75,7 @@ This section lists the retirement lifecycle for Foundry Models sold by Azure.
 | gpt-chat-latest | 2026-08-06 | Preview | 2026-12-02 | — |
 | gpt-image-1 | 2025-04-15 | Preview | 2026-10-23 | — |
 | gpt-image-1-mini | 2025-10-06 | GA | 2027-04-07 | — |
-| gpt-image-1.5 | 2025-12-16 | GA | 2027-06-16 | — |
+| gpt-image-1.5 | 2025-12-16 | GA | 2026-12-16 | — |
 | gpt-image-2 | 2026-04-21 | GA | 2027-10-21 | — |
 | gpt-realtime | 2025-08-28 | GA | 2027-03-02 | — |
 | gpt-realtime-1.5 | 2026-02-23 | GA | 2027-08-24 | — |


### PR DESCRIPTION
Updated the retirement date for gpt-image-1.5 from 2027-06-16 to 2026-12-16, to align with OpenAI's retirement schedule https://developers.openai.com/api/docs/deprecations#2026-06-02-gpt-image-model-deprecations and our own retirement date, shown in Foundry's model tile.