### PR TITLE
MAI-Transcribe: note the shorter recording length for speaker diarization

### DIFF
--- a/articles/ai-services/speech-service/mai-transcribe.md
+++ b/articles/ai-services/speech-service/mai-transcribe.md
@@ -7,7 +7,7 @@ author: PatrickFarley
 ms.author: pafarley
 ms.service: azure-speech-foundry-tools
 ms.topic: how-to
-ms.date: 09/03/2026
+ms.date: 09/05/2026
 ms.custom: references_regions
 zone_pivot_groups: llm-speech-quickstart
 ai-usage: ai-assisted
@@ -33,7 +33,7 @@ The following models are supported:
 > - An Azure subscription. You can [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn).
 > - [A Microsoft Foundry resource for Speech](https://portal.azure.com/#create/Microsoft.CognitiveServicesAIFoundry) in the Azure portal.
 > - The Speech resource key and region. After your Speech resource is deployed, select **Go to resource** to view and manage keys. For the current list of supported regions, see [Speech service regions](regions.md?tabs=llmspeech).
-> - An audio file (less than 300 MB in size) in one of these formats: WAV, MP3, or FLAC.
+> - An audio file (less than 300 MB in size) in one of these formats: WAV, MP3, or FLAC. For the maximum audio duration, see the `audio` parameter in the [Transcriptions - Transcribe](/rest/api/speechtotext/transcriptions/transcribe) REST reference. If you enable speaker diarization, see the note on recording length in the next section.
 
 
 ## Use a MAI-Transcribe model
@@ -44,13 +44,16 @@ Use MAI‑Transcribe‑2 to generate transcripts from audio input. Configure the
 | --- | :-- | :------------- | --- | --- |
 | **Model selection** _(Required)_ | `enhancedMode.`<br>`model` | `"MAI-Transcribe-2"`&nbsp; | — | **Set to call the MAI‑Transcribe model.** |
 | **Enhanced mode** _(Required)_ | `enhancedMode.`<br>`enabled` | `true`&nbsp;\|&nbsp;`false` | `false` | **Set to `true` to call MAI-Transcribe.** |
-| **Speaker diarization** | `diarization.`<br>`enabled` | `true`&nbsp;\|&nbsp;`false` | `false` | Segments the recording by speaker and attributes each segment to the correct person. Returns speaker-labelled segments with `speaker`, `offsetMilliseconds`, and `durationMilliseconds` metadata. |
+| **Speaker diarization** | `diarization.`<br>`enabled` | `true`&nbsp;\|&nbsp;`false` | `false` | Segments the recording by speaker and attributes each segment to the correct person. Returns speaker-labelled segments with `speaker`, `offsetMilliseconds`, and `durationMilliseconds` metadata. Supports shorter recordings than transcription without diarization; see the note that follows this table. |
 | **Word-level timestamps** | `modelOptions.`<br>`timestamps` | `"word"`&nbsp;\|&nbsp;`"segment"`&nbsp;\|&nbsp;`"none"` | `none` | Controls timing granularity. `"word"` returns `offsetMilliseconds` and `durationMilliseconds` for every word, enabling precise alignment, search, navigation, and editing. `"segment"` returns timing information for each segment: the output transcript is partitioned into segments by language and speaker. So when diarization is enabled, a segment is created for each speaker and language, and when it's disabled it's created for each language. `"none"` omits timing data. |
 | **Keyword biasing** | `phraseList.phrases` | Array of strings | `[]` | Biases recognition toward supplied keywords. Use for domain-specific terminology, abbreviations, product names, and proper nouns that are hard to disambiguate from context alone. Terms are hints, not forced output. |
 | **Transcription styles** | `modelOptions.`<br>`transcribeStyle` | `"verbatim"`&nbsp;\|&nbsp;`"clean"` | `"verbatim"` | Controls output style. `"verbatim"` captures speech exactly as spoken, including filler words and false starts, for compliance, QA, and analysis workloads. `clean` removes fillers to produce readable captions, notes, and published transcripts. |
 | **Language selection** | `locales` | [`"language_code"`] | *Unspecified (Automatic Detection)* | Allows forcing transcription in a specific language. This is a very strong hint to the model, and don't specify it unless you're absolutely certain that the recording is in the given language, and the default auto-detection doesn't work. Only one language can be provided here. MAI-Transcribe-2 supports 60 languages.|
 | **Code switching** | *Automatic* | — | — |  For commonly blended language pairs such as Hinglish and Spanglish, handles conversations that move between languages mid-utterance. |
 | **Noise robustness** | *Inherent* | — | — | Maintains transcription quality on audio recorded outside controlled environments, including background noise, overlapping speech, and variable microphone quality. |
+
+> [!NOTE]
+> Speaker diarization in enhanced mode currently supports shorter recordings than transcription does. In preview, requests with `diarization.enabled` set to `true` have failed for recordings of about 15 minutes and longer, returning HTTP 408 with a `Timeout` error, HTTP 500, or HTTP 503 with a `diarization_unavailable` error — while the same recordings transcribed successfully with diarization disabled, including a 73-minute file in a single request. These errors don't indicate a network or upload problem. For long recordings, transcribe with diarization disabled and use the returned word-level timestamps with a separate speaker diarization step.
 
 ::: zone pivot="ai-foundry"
 

--- a/articles/ai-services/speech-service/mai-transcribe.md
+++ b/articles/ai-services/speech-service/mai-transcribe.md
@@ -53,7 +53,7 @@ Use MAI‑Transcribe‑2 to generate transcripts from audio input. Configure the
 | **Noise robustness** | *Inherent* | — | — | Maintains transcription quality on audio recorded outside controlled environments, including background noise, overlapping speech, and variable microphone quality. |
 
 > [!NOTE]
-> Speaker diarization in enhanced mode currently supports shorter recordings than transcription does. In preview, requests with `diarization.enabled` set to `true` have failed for recordings of about 15 minutes and longer, returning HTTP 408 with a `Timeout` error, HTTP 500, or HTTP 503 with a `diarization_unavailable` error — while the same recordings transcribed successfully with diarization disabled, including a 73-minute file in a single request. These errors don't indicate a network or upload problem. For long recordings, transcribe with diarization disabled and use the returned word-level timestamps with a separate speaker diarization step.
+> Speaker diarization in enhanced mode currently supports shorter recordings than transcription does. In preview, requests with `diarization.enabled` set to `true` fail for recordings of about 15 minutes and longer, returning HTTP 408 with a `Timeout` error, HTTP 500, or HTTP 503 with a `diarization_unavailable` error, while the same recordings transcribed successfully with diarization disabled. For long recordings, transcribe with diarization disabled and use the returned word-level timestamps with a separate speaker diarization step.
 
 ::: zone pivot="ai-foundry"
 

--- a/articles/ai-services/speech-service/mai-transcribe.md
+++ b/articles/ai-services/speech-service/mai-transcribe.md
@@ -33,7 +33,7 @@ The following models are supported:
 > - An Azure subscription. You can [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn).
 > - [A Microsoft Foundry resource for Speech](https://portal.azure.com/#create/Microsoft.CognitiveServicesAIFoundry) in the Azure portal.
 > - The Speech resource key and region. After your Speech resource is deployed, select **Go to resource** to view and manage keys. For the current list of supported regions, see [Speech service regions](regions.md?tabs=llmspeech).
-> - An audio file (less than 300 MB in size) in one of these formats: WAV, MP3, or FLAC. For the maximum audio duration, see the `audio` parameter in the [Transcriptions - Transcribe](/rest/api/speechtotext/transcriptions/transcribe) REST reference. If you enable speaker diarization, see the note on recording length in the next section.
+> - An audio file in one of these formats: WAV, MP3, or FLAC. For the maximum file size and audio duration, see the `audio` parameter in the [Transcriptions - Transcribe](/rest/api/speechtotext/transcriptions/transcribe) REST reference. If you enable speaker diarization, see the note on recording length in the next section.
 
 
 ## Use a MAI-Transcribe model


### PR DESCRIPTION
## Summary

Adds a note to the MAI-Transcribe page that speaker diarization in enhanced mode supports shorter recordings than transcription does, cross-references it from the `diarization` parameter row, and points the prerequisites at the REST reference for the audio duration limit.

## Why

The page states a 300 MB size limit and no duration limit. In preview, requests to `transcriptions:transcribe?api-version=2025-10-15` with `enhancedMode.model` = `MAI-Transcribe-2` and `diarization.enabled` = `true` fail for recordings of about 15 minutes and longer. The same recordings transcribe successfully with diarization disabled — including a 73-minute, 70 MB MP3 in a single request — so the limit belongs to diarization, not to upload size, duration, or transcription.

Measured on 2026-09-04/05, region `eastus`, same resource throughout:

| audio | duration | size | diarization | result |
|---|---|---|---|---|
| clip | 25 s | 0.4 MB | on | 200 OK |
| recording, first 15 min | 15 min | 14.4 MB | on | 408 `Timeout` (×3) |
| recording, first 30 min | 30 min | 28.8 MB | on | 503 `diarization_unavailable` — "Diarization service returned error code 400" (×3) |
| full recording, re-encoded | 73 min | 17.5 MB | on | 408, then 500, then 503 |
| recording, first 30 min | 30 min | 28.8 MB | **off** | 200 OK |
| full recording, original | 73 min | 70.2 MB | **off** | 200 OK, 193 segments |

The 17.5 MB failure alongside the 70.2 MB success rules out size; the two successes with diarization off rule out duration and transcription.

The errors returned (`RequestTimeout`/`Timeout`, `InternalServerError`, `diarization_unavailable`) are relayed from the MAI service, are not in the documented `DetailedErrorCode` enum, and read as a network problem rather than a limit. Readers who hit them have no way to learn from this page that turning diarization off will succeed.

The note is written as observed behaviour rather than as a stated limit, because the actual limit isn't published; if the product team can supply the number, it should replace the observation.

## Related documentation inconsistency (not changed here)

Three pages currently state different input limits for the same endpoint: 5 hours / 500 MB (quotas page and LLM Speech how-to), "shorter than 2 hours … smaller than 250 MB" (REST reference, `audio` parameter, api-version 2025-10-15), and 300 MB with no duration (this page). This PR points at the REST reference for duration rather than restating a fourth figure; reconciling the three is left to the page owners.

## Checklist

- [x] Single page, three edits, no structural changes
- [x] Wording matches the page's existing `> [!NOTE]` and table style
- [x] Link to the REST reference uses the site-relative form used elsewhere on Learn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q46XJJkQkr2Y362c44fUNp
