### PR TITLE
Fix duplicated word "the the" in Agent Framework migration samples

### DIFF
--- a/agent-framework/migration-guide/from-semantic-kernel/samples.md
+++ b/agent-framework/migration-guide/from-semantic-kernel/samples.md
@@ -13,12 +13,12 @@ ms.service: agent-framework
 
 ::: zone pivot="programming-language-csharp"
 
-See the [Semantic Kernel repository](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/samples/AgentFrameworkMigration) for detailed per agent type code samples showing the the Agent Framework equivalent code for Semantic Kernel features.
+See the [Semantic Kernel repository](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/samples/AgentFrameworkMigration) for detailed per agent type code samples showing the Agent Framework equivalent code for Semantic Kernel features.
 
 ::: zone-end
 ::: zone pivot="programming-language-python"
 
-See the [Agent Framework repository](https://github.com/microsoft/agent-framework/tree/main/python/samples/semantic-kernel-migration) for detailed per agent type code samples showing the the Agent Framework equivalent code for Semantic Kernel features.
+See the [Agent Framework repository](https://github.com/microsoft/agent-framework/tree/main/python/samples/semantic-kernel-migration) for detailed per agent type code samples showing the Agent Framework equivalent code for Semantic Kernel features.
 
 ::: zone-end
 


### PR DESCRIPTION
Removes a repeated "the" ("the the" → "the") in two sentences (the C# and Python zone pivots) on the Semantic Kernel → Microsoft Agent Framework migration samples page (`agent-framework/migration-guide/from-semantic-kernel/samples.md`). Typo-only documentation fix; no content or link changes.