### PR TITLE
Fix max input tokens for gpt-audio and gpt-audio-mini (128,00 to 128,000)

### DIFF
--- a/articles/foundry/openai/includes/models-azure-direct-openai.md
+++ b/articles/foundry/openai/includes/models-azure-direct-openai.md
@@ -447,7 +447,7 @@ Details about maximum request tokens and training data are available in the foll
 |`gpt-4o-realtime-preview` (2025-06-03) | Audio model for real-time audio processing. |Input: 32,000  <br> Output: 4,096 | October 2023 |
 |`gpt-4o-realtime-preview` (2024-12-17) | Audio model for real-time audio processing. |Input: 16,000  <br> Output: 4,096 | October 2023 |
 |`gpt-4o-mini-realtime-preview` (2024-12-17)<br>**Preview** | Audio model for real-time audio processing. |Input: 128,000  <br> Output: 4,096 | October 2023 |
-|`gpt-audio`(2025-08-28)<br>`gpt-audio-mini`(2025-10-06) | Audio model for audio and text generation. |Input: 128,00  <br> Output: 16,384 | October 2023 |
+|`gpt-audio`(2025-08-28)<br>`gpt-audio-mini`(2025-10-06) | Audio model for audio and text generation. |Input: 128,000  <br> Output: 16,384 | October 2023 |
 |`gpt-realtime` (2025-08-28) (GA)<br>`gpt-realtime-mini` (2025-10-06)<br> `gpt-realtime-mini` (2025-12-15) | Audio model for real-time audio processing. |Input: 32,000  <br> Output: 4,096 | October 2023 |
 |`gpt-audio-1.5` (2026-02-23) | Audio model for audio and text generation. |Input: 128,000  <br> Output: 16,384 | September 2024 |
 |`gpt-realtime-1.5` (2026-02-23) | Audio model for real-time audio processing. |Input: 32,000  <br> Output: 4,096 | September 2024 |


### PR DESCRIPTION
The `gpt-audio` and `gpt-audio-mini` row in the audio models table gives a maximum input of `128,00`.  That is a dropped zero, and it should read `128,000`.

Two things make it unambiguous.  Every other row in the same table writes the figure in full, including `gpt-audio-1.5` a few rows below at `128,000`.  And OpenAI's own model pages give both `gpt-audio` and `gpt-audio-mini` a 128,000 token context window with a 16,384 token maximum output, which is the output figure this row already carries correctly.

Rendered page: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure

Source for the figure: https://platform.openai.com/docs/models/gpt-audio

This is one character in a single table cell, and nothing else is touched.
